### PR TITLE
Build linux and darwin arm64 binary

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -21,7 +21,7 @@ steps:
   - name: ls-lint
     image: byrnedo/alpine-curl
     commands:
-      - curl -sL -o ls-lint https://github.com/loeffel-io/ls-lint/releases/download/v1.8.1/ls-lint-linux && chmod +x ls-lint && ./ls-lint
+      - curl -sL -o ls-lint https://github.com/loeffel-io/ls-lint/releases/download/v1.9.2/ls-lint-linux && chmod +x ls-lint && ./ls-lint
 
   - name: test
     image: golang
@@ -56,7 +56,7 @@ steps:
       email: lucas@loeffel.io
       folder: npm
       access: public
-      # tag: beta
+      tag: beta
     when:
       event: tag
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -41,6 +41,7 @@ steps:
         from_secret: GITHUB_TOKEN
       files:
         - ls-lint-darwin
+        - ls-lint-darwin-arm64
         - ls-lint-linux
         - ls-lint-linux-arm64
         - ls-lint-windows.exe

--- a/.drone.yml
+++ b/.drone.yml
@@ -66,6 +66,9 @@ type: docker
 name: docker-linux-amd64
 depends_on:
   - main
+trigger:
+  ref:
+    - "refs/tags/**"
 
 platform:
   os: linux
@@ -86,8 +89,6 @@ steps:
       auto_tag: true
       auto_tag_suffix: linux-amd64
       repo: lslintorg/ls-lint
-    when:
-      event: tag
 
 ---
 kind: pipeline
@@ -95,6 +96,9 @@ type: docker
 name: docker-linux-arm64
 depends_on:
   - main
+trigger:
+  ref:
+    - "refs/tags/**"
 
 platform:
   os: linux
@@ -115,8 +119,6 @@ steps:
       auto_tag: true
       auto_tag_suffix: linux-arm64
       repo: lslintorg/ls-lint
-    when:
-      event: tag
 
 ---
 kind: pipeline
@@ -125,6 +127,9 @@ name: docker-manifest
 depends_on:
   - docker-linux-amd64
   - docker-linux-arm64
+trigger:
+  ref:
+    - "refs/tags/**"
 
 platform:
   os: linux
@@ -142,5 +147,3 @@ steps:
       username: loeffel
       password:
         from_secret: DOCKER_PASSWORD
-    when:
-      event: tag

--- a/.drone.yml
+++ b/.drone.yml
@@ -142,7 +142,6 @@ steps:
     image: plugins/manifest
     settings:
       auto_tag: true
-      ignore_missing: true
       spec: docker/manifest.tmpl
       repo: lslintorg/ls-lint
       username: loeffel

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,10 @@
 kind: pipeline
 type: docker
-name: docker
+name: main
+
+platform:
+  os: linux
+  arch: amd64
 
 steps:
   - name: install
@@ -55,14 +59,79 @@ steps:
     when:
       event: tag
 
-  - name: docker hub
-    image: plugins/docker
+---
+kind: pipeline
+type: docker
+name: docker-linux-amd64
+depends_on:
+  - main
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+    - name: docker hub
+    image: plugins/docker:linux-amd64
     settings:
       username: loeffel
       password:
         from_secret: DOCKER_PASSWORD
       dockerfile: docker/Dockerfile
       auto_tag: true
+    auto_tag_suffix: linux-amd64
       repo: lslintorg/ls-lint
     when:
       event: tag
+
+---
+kind: pipeline
+type: docker
+name: docker-linux-arm64
+depends_on:
+  - main
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+  - name: docker hub
+  image: plugins/docker:linux-arm64
+  settings:
+    username: loeffel
+    password:
+      from_secret: DOCKER_PASSWORD
+    dockerfile: docker/Dockerfile.arm64
+    auto_tag: true
+    auto_tag_suffix: linux-arm64
+    repo: lslintorg/ls-lint
+  when:
+    event: tag
+
+---
+kind: pipeline
+type: docker
+name: docker-manifest
+depends_on:
+  - docker-linux-amd64
+  - docker-linux-arm64
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+  - name: manifest
+  pull: always
+  image: plugins/manifest
+  settings:
+    auto_tag: true
+    ignore_missing: true
+    spec: docker/manifest.tmpl
+    repo: lslintorg/ls-lint
+    username: loeffel
+    password:
+      from_secret: DOCKER_PASSWORD
+  when:
+    event: tag

--- a/.drone.yml
+++ b/.drone.yml
@@ -72,6 +72,10 @@ platform:
   arch: amd64
 
 steps:
+  - name: build
+    image: golang
+    commands:
+      - make build
   - name: docker hub
     image: plugins/docker:linux-amd64
     settings:
@@ -97,6 +101,10 @@ platform:
   arch: arm64
 
 steps:
+  - name: build
+    image: golang
+    commands:
+      - make build
   - name: docker hub
     image: plugins/docker:linux-arm64
     settings:

--- a/.drone.yml
+++ b/.drone.yml
@@ -67,8 +67,8 @@ name: docker-linux-amd64
 depends_on:
   - main
 trigger:
-  ref:
-    - "refs/tags/**"
+  event:
+    - tag
 
 platform:
   os: linux
@@ -97,8 +97,8 @@ name: docker-linux-arm64
 depends_on:
   - main
 trigger:
-  ref:
-    - "refs/tags/**"
+  event:
+    - tag
 
 platform:
   os: linux
@@ -128,8 +128,8 @@ depends_on:
   - docker-linux-amd64
   - docker-linux-arm64
 trigger:
-  ref:
-    - "refs/tags/**"
+  event:
+    - tag
 
 platform:
   os: linux

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,3 +1,4 @@
+---
 kind: pipeline
 type: docker
 name: main
@@ -71,7 +72,7 @@ platform:
   arch: amd64
 
 steps:
-    - name: docker hub
+  - name: docker hub
     image: plugins/docker:linux-amd64
     settings:
       username: loeffel
@@ -79,7 +80,7 @@ steps:
         from_secret: DOCKER_PASSWORD
       dockerfile: docker/Dockerfile
       auto_tag: true
-    auto_tag_suffix: linux-amd64
+      auto_tag_suffix: linux-amd64
       repo: lslintorg/ls-lint
     when:
       event: tag
@@ -97,17 +98,17 @@ platform:
 
 steps:
   - name: docker hub
-  image: plugins/docker:linux-arm64
-  settings:
-    username: loeffel
-    password:
-      from_secret: DOCKER_PASSWORD
-    dockerfile: docker/Dockerfile.arm64
-    auto_tag: true
-    auto_tag_suffix: linux-arm64
-    repo: lslintorg/ls-lint
-  when:
-    event: tag
+    image: plugins/docker:linux-arm64
+    settings:
+      username: loeffel
+      password:
+        from_secret: DOCKER_PASSWORD
+      dockerfile: docker/Dockerfile.arm64
+      auto_tag: true
+      auto_tag_suffix: linux-arm64
+      repo: lslintorg/ls-lint
+    when:
+      event: tag
 
 ---
 kind: pipeline
@@ -123,15 +124,15 @@ platform:
 
 steps:
   - name: manifest
-  pull: always
-  image: plugins/manifest
-  settings:
-    auto_tag: true
-    ignore_missing: true
-    spec: docker/manifest.tmpl
-    repo: lslintorg/ls-lint
-    username: loeffel
-    password:
-      from_secret: DOCKER_PASSWORD
-  when:
-    event: tag
+    pull: always
+    image: plugins/manifest
+    settings:
+      auto_tag: true
+      ignore_missing: true
+      spec: docker/manifest.tmpl
+      repo: lslintorg/ls-lint
+      username: loeffel
+      password:
+        from_secret: DOCKER_PASSWORD
+    when:
+      event: tag

--- a/.drone.yml
+++ b/.drone.yml
@@ -37,6 +37,7 @@ steps:
       files:
         - ls-lint-darwin
         - ls-lint-linux
+        - ls-lint-linux-arm64
         - ls-lint-windows.exe
     when:
       event: tag

--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,14 @@ test-coverage:
 build:
 	GOOS=darwin GOARCH=amd64 go build -o ls-lint-darwin
 	GOOS=linux GOARCH=amd64 go build -o ls-lint-linux
+	GOOS=linux GOARCH=arm64 go build -o ls-lint-linux-arm64
 	GOOS=windows GOARCH=amd64 go build -o ls-lint-windows.exe
 
 build-npm:
 	cp README.md npm/README.md
 	make build-npm-darwin
 	make build-npm-linux
+	make build-npm-linux-arm64
 	make build-npm-windows
 
 build-npm-darwin:
@@ -25,6 +27,10 @@ build-npm-darwin:
 build-npm-linux:
 	cp ls-lint-linux npm/bin/ls-lint-linux
 	chmod +x npm/bin/ls-lint-linux
+
+build-npm-linux-arm64:
+	cp ls-lint-linux-arm64 npm/bin/ls-lint-linux-arm64
+	chmod +x npm/bin/ls-lint-linux-arm64
 
 build-npm-windows:
 	cp ls-lint-windows.exe npm/bin/ls-lint-windows.exe

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ test-coverage:
 
 build:
 	GOOS=darwin GOARCH=amd64 go build -o ls-lint-darwin
+	GOOS=darwin GOARCH=arm64 go build -o ls-lint-darwin-arm64
 	GOOS=linux GOARCH=amd64 go build -o ls-lint-linux
 	GOOS=linux GOARCH=arm64 go build -o ls-lint-linux-arm64
 	GOOS=windows GOARCH=amd64 go build -o ls-lint-windows.exe
@@ -16,6 +17,7 @@ build:
 build-npm:
 	cp README.md npm/README.md
 	make build-npm-darwin
+	make build-npm-darwin-arm64
 	make build-npm-linux
 	make build-npm-linux-arm64
 	make build-npm-windows
@@ -23,6 +25,10 @@ build-npm:
 build-npm-darwin:
 	cp ls-lint-darwin npm/bin/ls-lint-darwin
 	chmod +x npm/bin/ls-lint-darwin
+
+build-npm-darwin-arm64:
+	cp ls-lint-darwin-arm64 npm/bin/ls-lint-darwin-arm64
+	chmod +x npm/bin/ls-lint-darwin-arm64
 
 build-npm-linux:
 	cp ls-lint-linux npm/bin/ls-lint-linux

--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -1,0 +1,6 @@
+FROM gcr.io/distroless/base
+
+COPY ls-lint-linux-arm64 ls-lint
+VOLUME /data
+WORKDIR /data
+CMD ["/ls-lint"]

--- a/docker/manifest.tmpl
+++ b/docker/manifest.tmpl
@@ -1,0 +1,19 @@
+image: lslintorg/ls-lint:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}
+{{#if build.tags}}
+tags:
+{{#each build.tags}}
+  - {{this}}
+{{/each}}
+{{/if}}
+manifests:
+  -
+    image: lslintorg/ls-lint:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-amd64
+    platform:
+      architecture: amd64
+      os: linux
+  -
+    image: lslintorg/ls-lint:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-arm64
+    platform:
+      architecture: arm64
+      os: linux
+      variant: v8

--- a/npm/bin/cli.js
+++ b/npm/bin/cli.js
@@ -24,7 +24,12 @@ function getPlatformPath() {
     case 'darwin':
       return 'ls-lint-darwin';
     case 'linux':
-      return 'ls-lint-linux';
+      switch (process.arch) {
+	case 'x64':
+          return 'ls-lint-linux';
+        case 'arm64':
+	  return 'ls-lint-linux-arm64';
+      }
     case 'win32':
       return 'ls-lint-windows.exe';
     default:

--- a/npm/bin/cli.js
+++ b/npm/bin/cli.js
@@ -22,13 +22,25 @@ function spawnCommand(binaryExecutable) {
 function getPlatformPath() {
   switch (process.platform) {
     case 'darwin':
+      switch (process.arch) {
+        case 'x64':
+          return 'ls-lint-darwin';
+        case 'arm64':
+          return 'ls-lint-linux-arm64';
+        default:
+          console.log('ls-lint builds are not available on platform: ' + process.platform + ' arch: ' + process.arch);
+          process.exit(1);
+      }
       return 'ls-lint-darwin';
     case 'linux':
       switch (process.arch) {
-	case 'x64':
+        case 'x64':
           return 'ls-lint-linux';
         case 'arm64':
-	  return 'ls-lint-linux-arm64';
+          return 'ls-lint-linux-arm64';
+        default:
+          console.log('ls-lint builds are not available on platform: ' + process.platform + ' arch: ' + process.arch);
+          process.exit(1);
       }
     case 'win32':
       return 'ls-lint-windows.exe';

--- a/npm/package.json
+++ b/npm/package.json
@@ -14,7 +14,8 @@
     "win32"
   ],
   "cpu": [
-    "x64"
+    "x64",
+    "arm64"
   ],
   "keywords": [
     "linter",

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ls-lint/ls-lint",
-  "version": "1.9.2",
+  "version": "1.10.0-beta.1",
   "description": "The 64-bit binary for ls-lint",
   "repository": "https://github.com/loeffel-io/ls-lint",
   "license": "MIT",


### PR DESCRIPTION
This allow using ls-lint on Linux run on arm64 CPU (Raspberry Pi4, Rock Pi4, AWS EC2 with AWS Graviton CPU (A1, T4g, C6g, M6g, R6g)).