### PR TITLE
Fix ls-lint-darwin-arm64 platform path

### DIFF
--- a/npm/bin/cli.js
+++ b/npm/bin/cli.js
@@ -26,7 +26,7 @@ function getPlatformPath() {
         case 'x64':
           return 'ls-lint-darwin';
         case 'arm64':
-          return 'ls-lint-linux-arm64';
+          return 'ls-lint-darwin-arm64';
         default:
           console.log('ls-lint builds are not available on platform: ' + process.platform + ' arch: ' + process.arch);
           process.exit(1);


### PR DESCRIPTION
This fixes a typo and is related to #43