### PR TITLE
Add glob support to ignores

### DIFF
--- a/config.go
+++ b/config.go
@@ -181,7 +181,7 @@ func (config *Config) globIndex(filesystem fs.FS, index index) (err error) {
 	return nil
 }
 
-func (config *Config) globIgnoreIndex(filesystem fs.FS, index map[string]bool) (err error) {
+func globIgnoreIndex(config *Config, filesystem fs.FS, index map[string]bool) (err error) {
 	for key, value := range index {
 		var matches []string
 

--- a/config.go
+++ b/config.go
@@ -145,43 +145,7 @@ func (config *Config) getIndex(list ls) (index, error) {
 	return index, nil
 }
 
-func (config *Config) globIndex(filesystem fs.FS, index index) (err error) {
-	for key, value := range index {
-		var matches []string
-
-		if !strings.ContainsAny(key, "*{}") {
-			continue
-		}
-
-		if matches, err = doublestar.Glob(filesystem, key); err != nil {
-			return err
-		}
-
-		if len(matches) == 0 {
-			delete(index, key)
-			continue
-		}
-
-		for _, match := range matches {
-			var matchInfo fs.FileInfo
-
-			if matchInfo, err = fs.Stat(filesystem, match); err != nil {
-				return err
-			}
-
-			if !matchInfo.IsDir() {
-				continue
-			}
-
-			index[match] = value
-			delete(index, key)
-		}
-	}
-
-	return nil
-}
-
-func globIgnoreIndex[V bool | map[string][]Rule](config *Config, filesystem fs.FS, index map[string]V) (err error) {
+func globIndex[V bool | map[string][]Rule](config *Config, filesystem fs.FS, index map[string]V) (err error) {
 	for key, value := range index {
 		var matches []string
 

--- a/config.go
+++ b/config.go
@@ -145,7 +145,7 @@ func (config *Config) getIndex(list ls) (index, error) {
 	return index, nil
 }
 
-func globIndex[V bool | map[string][]Rule](config *Config, filesystem fs.FS, index map[string]V) (err error) {
+func globIndex[V bool | map[string][]Rule](filesystem fs.FS, index map[string]V) (err error) {
 	for key, value := range index {
 		var matches []string
 

--- a/config.go
+++ b/config.go
@@ -181,7 +181,7 @@ func (config *Config) globIndex(filesystem fs.FS, index index) (err error) {
 	return nil
 }
 
-func globIgnoreIndex(config *Config, filesystem fs.FS, index map[string]bool) (err error) {
+func globIgnoreIndex[V bool | map[string][]Rule](config *Config, filesystem fs.FS, index map[string]V) (err error) {
 	for key, value := range index {
 		var matches []string
 

--- a/linter.go
+++ b/linter.go
@@ -153,12 +153,11 @@ func (linter *Linter) Run(filesystem fs.FS, config *Config, debug bool, statisti
 		return err
 	}
 
-	// glob index
-	if err := config.globIndex(filesystem, index); err != nil {
+	if err := globIndex(config, filesystem, index); err != nil {
 		return err
 	}
 
-	if err := globIgnoreIndex(config, filesystem, ignoreIndex); err != nil {
+	if err := globIndex(config, filesystem, ignoreIndex); err != nil {
 		return err
 	}
 

--- a/linter.go
+++ b/linter.go
@@ -153,11 +153,13 @@ func (linter *Linter) Run(filesystem fs.FS, config *Config, debug bool, statisti
 		return err
 	}
 
-	if err := globIndex(config, filesystem, index); err != nil {
+	// apply globbing to the index
+	if err := globIndex(filesystem, index); err != nil {
 		return err
 	}
 
-	if err := globIndex(config, filesystem, ignoreIndex); err != nil {
+	// apply globbing to the ignore index
+	if err := globIndex(filesystem, ignoreIndex); err != nil {
 		return err
 	}
 

--- a/linter.go
+++ b/linter.go
@@ -158,6 +158,10 @@ func (linter *Linter) Run(filesystem fs.FS, config *Config, debug bool, statisti
 		return err
 	}
 
+	if err := config.globIgnoreIndex(filesystem, ignoreIndex); err != nil {
+		return err
+	}
+
 	return fs.WalkDir(filesystem, ".", func(path string, info fs.DirEntry, err error) error {
 		if config.shouldIgnore(ignoreIndex, path) {
 			if info.IsDir() {

--- a/linter.go
+++ b/linter.go
@@ -158,7 +158,7 @@ func (linter *Linter) Run(filesystem fs.FS, config *Config, debug bool, statisti
 		return err
 	}
 
-	if err := config.globIgnoreIndex(filesystem, ignoreIndex); err != nil {
+	if err := globIgnoreIndex(config, filesystem, ignoreIndex); err != nil {
 		return err
 	}
 

--- a/linter_test.go
+++ b/linter_test.go
@@ -229,6 +229,41 @@ func TestLinterRun(t *testing.T) {
 			},
 		},
 		{
+			description: "Invalid glob in config",
+			filesystem:  fstest.MapFS{},
+			config: &Config{
+				Ls: ls{
+					"src/{a,b/*": ls{
+						".png": "kebab-case",
+					},
+				},
+				Ignore:  []string{},
+				RWMutex: new(sync.RWMutex),
+			},
+			linter: &Linter{
+				Statistic: &Statistic{
+					Start:     start,
+					Files:     0,
+					FileSkips: 0,
+					Dirs:      0,
+					DirSkips:  0,
+					RWMutex:   new(sync.RWMutex),
+				},
+				Errors:  []*Error{},
+				RWMutex: new(sync.RWMutex),
+			},
+			expectedErr: doublestar.ErrBadPattern,
+			expectedStatistic: &Statistic{
+				Start:     start,
+				Files:     0,
+				FileSkips: 0,
+				Dirs:      0,
+				DirSkips:  0,
+				RWMutex:   new(sync.RWMutex),
+			},
+			expectedErrors: []*Error{},
+		},
+		{
 			description: "No violations with glob in ignores",
 			filesystem: fstest.MapFS{
 				"a/c":                         &fstest.MapFile{Mode: fs.ModeDir},

--- a/linter_test.go
+++ b/linter_test.go
@@ -242,7 +242,7 @@ func TestLinterRun(t *testing.T) {
 					".png": "snake_case",
 				},
 				Ignore: []string{
-					"**/c/**",
+					"*/c",
 				},
 				RWMutex: new(sync.RWMutex),
 			},

--- a/linter_test.go
+++ b/linter_test.go
@@ -12,6 +12,17 @@ import (
 	"time"
 )
 
+func emptyStatistics(start time.Time) *Statistic {
+	return &Statistic{
+		Start:     start,
+		Files:     0,
+		FileSkips: 0,
+		Dirs:      0,
+		DirSkips:  0,
+		RWMutex:   new(sync.RWMutex),
+	}
+}
+
 func TestLinterRun(t *testing.T) {
 	var start = time.Now()
 
@@ -45,16 +56,9 @@ func TestLinterRun(t *testing.T) {
 				RWMutex: new(sync.RWMutex),
 			},
 			linter: &Linter{
-				Statistic: &Statistic{
-					Start:     start,
-					Files:     0,
-					FileSkips: 0,
-					Dirs:      0,
-					DirSkips:  0,
-					RWMutex:   new(sync.RWMutex),
-				},
-				Errors:  []*Error{},
-				RWMutex: new(sync.RWMutex),
+				Statistic: emptyStatistics(start),
+				Errors:    []*Error{},
+				RWMutex:   new(sync.RWMutex),
 			},
 			expectedErr: nil,
 			expectedStatistic: &Statistic{
@@ -80,16 +84,9 @@ func TestLinterRun(t *testing.T) {
 				RWMutex: new(sync.RWMutex),
 			},
 			linter: &Linter{
-				Statistic: &Statistic{
-					Start:     start,
-					Files:     0,
-					FileSkips: 0,
-					Dirs:      0,
-					DirSkips:  0,
-					RWMutex:   new(sync.RWMutex),
-				},
-				Errors:  []*Error{},
-				RWMutex: new(sync.RWMutex),
+				Statistic: emptyStatistics(start),
+				Errors:    []*Error{},
+				RWMutex:   new(sync.RWMutex),
 			},
 			expectedErr: nil,
 			expectedStatistic: &Statistic{
@@ -143,16 +140,9 @@ func TestLinterRun(t *testing.T) {
 				RWMutex: new(sync.RWMutex),
 			},
 			linter: &Linter{
-				Statistic: &Statistic{
-					Start:     start,
-					Files:     0,
-					FileSkips: 0,
-					Dirs:      0,
-					DirSkips:  0,
-					RWMutex:   new(sync.RWMutex),
-				},
-				Errors:  []*Error{},
-				RWMutex: new(sync.RWMutex),
+				Statistic: emptyStatistics(start),
+				Errors:    []*Error{},
+				RWMutex:   new(sync.RWMutex),
 			},
 			expectedErr: nil,
 			expectedStatistic: &Statistic{
@@ -198,16 +188,9 @@ func TestLinterRun(t *testing.T) {
 				RWMutex: new(sync.RWMutex),
 			},
 			linter: &Linter{
-				Statistic: &Statistic{
-					Start:     start,
-					Files:     0,
-					FileSkips: 0,
-					Dirs:      0,
-					DirSkips:  0,
-					RWMutex:   new(sync.RWMutex),
-				},
-				Errors:  []*Error{},
-				RWMutex: new(sync.RWMutex),
+				Statistic: emptyStatistics(start),
+				Errors:    []*Error{},
+				RWMutex:   new(sync.RWMutex),
 			},
 			expectedErr: nil,
 			expectedStatistic: &Statistic{
@@ -241,27 +224,13 @@ func TestLinterRun(t *testing.T) {
 				RWMutex: new(sync.RWMutex),
 			},
 			linter: &Linter{
-				Statistic: &Statistic{
-					Start:     start,
-					Files:     0,
-					FileSkips: 0,
-					Dirs:      0,
-					DirSkips:  0,
-					RWMutex:   new(sync.RWMutex),
-				},
-				Errors:  []*Error{},
-				RWMutex: new(sync.RWMutex),
-			},
-			expectedErr: doublestar.ErrBadPattern,
-			expectedStatistic: &Statistic{
-				Start:     start,
-				Files:     0,
-				FileSkips: 0,
-				Dirs:      0,
-				DirSkips:  0,
+				Statistic: emptyStatistics(start),
+				Errors:    []*Error{},
 				RWMutex:   new(sync.RWMutex),
 			},
-			expectedErrors: []*Error{},
+			expectedErr:       doublestar.ErrBadPattern,
+			expectedStatistic: emptyStatistics(start),
+			expectedErrors:    []*Error{},
 		},
 		{
 			description: "No violations with glob in ignores",
@@ -283,16 +252,9 @@ func TestLinterRun(t *testing.T) {
 				RWMutex: new(sync.RWMutex),
 			},
 			linter: &Linter{
-				Statistic: &Statistic{
-					Start:     start,
-					Files:     0,
-					FileSkips: 0,
-					Dirs:      0,
-					DirSkips:  0,
-					RWMutex:   new(sync.RWMutex),
-				},
-				Errors:  []*Error{},
-				RWMutex: new(sync.RWMutex),
+				Statistic: emptyStatistics(start),
+				Errors:    []*Error{},
+				RWMutex:   new(sync.RWMutex),
 			},
 			expectedErr: nil,
 			expectedStatistic: &Statistic{
@@ -323,16 +285,9 @@ func TestLinterRun(t *testing.T) {
 				RWMutex: new(sync.RWMutex),
 			},
 			linter: &Linter{
-				Statistic: &Statistic{
-					Start:     start,
-					Files:     0,
-					FileSkips: 0,
-					Dirs:      0,
-					DirSkips:  0,
-					RWMutex:   new(sync.RWMutex),
-				},
-				Errors:  []*Error{},
-				RWMutex: new(sync.RWMutex),
+				Statistic: emptyStatistics(start),
+				Errors:    []*Error{},
+				RWMutex:   new(sync.RWMutex),
 			},
 			expectedErr: nil,
 			expectedStatistic: &Statistic{
@@ -358,27 +313,13 @@ func TestLinterRun(t *testing.T) {
 				RWMutex: new(sync.RWMutex),
 			},
 			linter: &Linter{
-				Statistic: &Statistic{
-					Start:     start,
-					Files:     0,
-					FileSkips: 0,
-					Dirs:      0,
-					DirSkips:  0,
-					RWMutex:   new(sync.RWMutex),
-				},
-				Errors:  []*Error{},
-				RWMutex: new(sync.RWMutex),
-			},
-			expectedErr: doublestar.ErrBadPattern,
-			expectedStatistic: &Statistic{
-				Start:     start,
-				Files:     0,
-				FileSkips: 0,
-				Dirs:      0,
-				DirSkips:  0,
+				Statistic: emptyStatistics(start),
+				Errors:    []*Error{},
 				RWMutex:   new(sync.RWMutex),
 			},
-			expectedErrors: []*Error{},
+			expectedErr:       doublestar.ErrBadPattern,
+			expectedStatistic: emptyStatistics(start),
+			expectedErrors:    []*Error{},
 		},
 	}
 

--- a/linter_test.go
+++ b/linter_test.go
@@ -24,7 +24,7 @@ func TestLinterRun(t *testing.T) {
 		expectedErrors    []*Error
 	}{
 		{
-			description: "success",
+			description: "No violations detected",
 			filesystem: fstest.MapFS{
 				"snake_case.png":              &fstest.MapFile{Mode: fs.ModePerm},
 				"kebab-case.png":              &fstest.MapFile{Mode: fs.ModePerm},
@@ -67,7 +67,7 @@ func TestLinterRun(t *testing.T) {
 			expectedErrors: []*Error{},
 		},
 		{
-			description: "fail",
+			description: "Single file violation",
 			filesystem: fstest.MapFS{
 				"not-snake-case.png": &fstest.MapFile{Mode: fs.ModePerm},
 			},
@@ -110,7 +110,7 @@ func TestLinterRun(t *testing.T) {
 			},
 		},
 		{
-			description: "glob",
+			description: "No violations with globs in config",
 			filesystem: fstest.MapFS{
 				"snake_case.png":                  &fstest.MapFile{Mode: fs.ModePerm},
 				"src/a/a":                         &fstest.MapFile{Mode: fs.ModeDir},
@@ -165,7 +165,7 @@ func TestLinterRun(t *testing.T) {
 			expectedErrors: []*Error{},
 		},
 		{
-			description: "glob (fail)",
+			description: "Violations with glob in config",
 			filesystem: fstest.MapFS{
 				"snake_case.png":                      &fstest.MapFile{Mode: fs.ModePerm},
 				"src/a/a":                             &fstest.MapFile{Mode: fs.ModeDir},

--- a/linter_test.go
+++ b/linter_test.go
@@ -269,6 +269,46 @@ func TestLinterRun(t *testing.T) {
 			},
 			expectedErrors: []*Error{},
 		},
+		{
+			description: "No violations with alternatives in ignores",
+			filesystem: fstest.MapFS{
+				"a/c":                    &fstest.MapFile{Mode: fs.ModeDir},
+				"b/c":                    &fstest.MapFile{Mode: fs.ModeDir},
+				"a/c/not-snake-case.png": &fstest.MapFile{Mode: fs.ModePerm},
+				"b/c/not-snake-case.png": &fstest.MapFile{Mode: fs.ModePerm},
+			},
+			config: &Config{
+				Ls: ls{
+					".png": "snake_case",
+				},
+				Ignore: []string{
+					"{a,b}/c",
+				},
+				RWMutex: new(sync.RWMutex),
+			},
+			linter: &Linter{
+				Statistic: &Statistic{
+					Start:     start,
+					Files:     0,
+					FileSkips: 0,
+					Dirs:      0,
+					DirSkips:  0,
+					RWMutex:   new(sync.RWMutex),
+				},
+				Errors:  []*Error{},
+				RWMutex: new(sync.RWMutex),
+			},
+			expectedErr: nil,
+			expectedStatistic: &Statistic{
+				Start:     start,
+				Files:     0,
+				FileSkips: 0,
+				Dirs:      3,
+				DirSkips:  2,
+				RWMutex:   new(sync.RWMutex),
+			},
+			expectedErrors: []*Error{},
+		},
 	}
 
 	var i = 0

--- a/linter_test.go
+++ b/linter_test.go
@@ -227,6 +227,48 @@ func TestLinterRun(t *testing.T) {
 				},
 			},
 		},
+		{
+			description: "No violations with glob in ignores",
+			filesystem: fstest.MapFS{
+				"a/c":                         &fstest.MapFile{Mode: fs.ModeDir},
+				"b/c":                         &fstest.MapFile{Mode: fs.ModeDir},
+				"a/c/not-snake-case.png":      &fstest.MapFile{Mode: fs.ModePerm},
+				"a/c/also-not-snake-case.png": &fstest.MapFile{Mode: fs.ModePerm},
+				"b/c/not-snake-case.png":      &fstest.MapFile{Mode: fs.ModePerm},
+				"b/c/also-not-snake-case.png": &fstest.MapFile{Mode: fs.ModePerm},
+			},
+			config: &Config{
+				Ls: ls{
+					".png": "snake_case",
+				},
+				Ignore: []string{
+					"**/c/**",
+				},
+				RWMutex: new(sync.RWMutex),
+			},
+			linter: &Linter{
+				Statistic: &Statistic{
+					Start:     start,
+					Files:     0,
+					FileSkips: 0,
+					Dirs:      0,
+					DirSkips:  0,
+					RWMutex:   new(sync.RWMutex),
+				},
+				Errors:  []*Error{},
+				RWMutex: new(sync.RWMutex),
+			},
+			expectedErr: nil,
+			expectedStatistic: &Statistic{
+				Start:     start,
+				Files:     0,
+				FileSkips: 0,
+				Dirs:      3,
+				DirSkips:  2,
+				RWMutex:   new(sync.RWMutex),
+			},
+			expectedErrors: []*Error{},
+		},
 	}
 
 	var i = 0

--- a/linter_test.go
+++ b/linter_test.go
@@ -241,11 +241,14 @@ func TestLinterRun(t *testing.T) {
 		}
 
 		if !reflect.DeepEqual(test.linter.getStatistic(), test.expectedStatistic) {
-			t.Errorf("Test %d (%s) failed with unmatched linter statistic values\nexpected: %+v\nactual: %+v", i, test.description, test.expectedStatistic, test.linter.getStatistic())
+			t.Errorf("Test %d (%s) failed with unmatched linter statistic values\nexpected: %+v\nactual: %+v",
+				i, test.description, test.expectedStatistic, test.linter.getStatistic())
 			return
 		}
 
-		var equalErrorsErr = fmt.Errorf("Test %d (%s) failed with unmatched linter errors value\nexpected: %+v\nactual: %+v", i, test.description, test.expectedErrors, test.linter.getErrors())
+		var equalErrorsErr = fmt.Errorf("Test %d (%s) failed with unmatched linter errors value\nexpected: %+v\nactual: %+v",
+			i, test.description, test.expectedErrors, test.linter.getErrors())
+
 		if len(test.linter.getErrors()) != len(test.expectedErrors) {
 			t.Error(equalErrorsErr)
 			return

--- a/linter_test.go
+++ b/linter_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"github.com/bmatcuk/doublestar/v4"
 	"io/fs"
 	"reflect"
 	"sync"
@@ -305,6 +306,41 @@ func TestLinterRun(t *testing.T) {
 				FileSkips: 0,
 				Dirs:      3,
 				DirSkips:  2,
+				RWMutex:   new(sync.RWMutex),
+			},
+			expectedErrors: []*Error{},
+		},
+		{
+			description: "Invalid glob in ignore",
+			filesystem:  fstest.MapFS{},
+			config: &Config{
+				Ls: ls{
+					".png": "snake_case",
+				},
+				Ignore: []string{
+					"{a/c",
+				},
+				RWMutex: new(sync.RWMutex),
+			},
+			linter: &Linter{
+				Statistic: &Statistic{
+					Start:     start,
+					Files:     0,
+					FileSkips: 0,
+					Dirs:      0,
+					DirSkips:  0,
+					RWMutex:   new(sync.RWMutex),
+				},
+				Errors:  []*Error{},
+				RWMutex: new(sync.RWMutex),
+			},
+			expectedErr: doublestar.ErrBadPattern,
+			expectedStatistic: &Statistic{
+				Start:     start,
+				Files:     0,
+				FileSkips: 0,
+				Dirs:      0,
+				DirSkips:  0,
 				RWMutex:   new(sync.RWMutex),
 			},
 			expectedErrors: []*Error{},


### PR DESCRIPTION
As is on the v2 wishlist and was mentioned in https://github.com/loeffel-io/ls-lint/issues/35 and https://github.com/loeffel-io/ls-lint/issues/56#issuecomment-909418833, globbing is currently not allowed for the `ignore` key.

This is a first try at implementing this.

* [x] Performance implications?
* [ ] Documentation?
* [ ] Haven't found a changelog

### Performance

All measurements done on an 2020 M1 MacBook Air with 8GB of ram.
Using hyperfine, I ran `hyperfine './ls-lint'` with the current local build of ls-lint as well as with master. I did a couple variations, based on the [example config](https://github.com/loeffel-io/ls-lint/blob/master/examples/nuxt-nuxt-js/.ls-lint.yml):

| build | config | result |
| ----- | ------ | ------ |
| this branch | with `node_modules` in ignore | `Time (mean ± σ):      16.0 ms ±   0.8 ms    [User: 7.4 ms, System: 8.7 ms]` |
| this branch | with `'**/node_modules'` in ignore | `Time (mean ± σ):     282.4 ms ±  21.8 ms    [User: 71.7 ms, System: 210.1 ms]` |
| master | with `node_module` in ignore | `Time (mean ± σ):      15.9 ms ±   0.7 ms    [User: 7.3 ms, System: 8.7 ms]` |

This kind of confirms what makes some sense: If you use a glob in ignores, depending on the size of your project, you pay a _significant_ penalty in performance. If you don't use any globs, you don't pay measurably.
