### PR TITLE
Add config flag and support .yaml #29

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,8 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"gopkg.in/yaml.v3"
-	"io"
 	"log"
 	"os"
 	"path"
@@ -39,53 +37,8 @@ func main() {
 		Errors:    make([]*Error, 0),
 		RWMutex:   new(sync.RWMutex),
 	}
-	// if config_file is default, see if there's an `.ls-lint.yaml` file instead
-	if *config_file == ".ls-lint.yml" {
-		files, err := os.ReadDir(cwd)
-		if err != nil {
-			log.Fatal(err)
-		}
 	
-		for _, file := range files {
-			match, match_err := path.Match(".ls-lint.y*ml", file.Name())
-			if match_err != nil {
-				log.Fatal(match_err)
-			}
-			if match {
-				*config_file = file.Name()
-				break
-			}
-		}
-	}
-	// open config file
-	file, err := os.Open(*config_file)
-
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	// close file
-	defer func() {
-		err = file.Close()
-
-		if err != nil {
-			log.Fatal(err)
-		}
-	}()
-
-	// read file
-	configBytes, err := io.ReadAll(file)
-
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	// to yaml
-	err = yaml.Unmarshal(configBytes, &config)
-
-	if err != nil {
-		log.Fatal(err)
-	}
+	read_config_file(cwd, *config_file, config)
 
 	// runner
 	if err := linter.Run(filesystem, config, *debug, false); err != nil {

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"gopkg.in/yaml.v3"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"path"
@@ -74,7 +74,7 @@ func main() {
 	}()
 
 	// read file
-	configBytes, err := ioutil.ReadAll(file)
+	configBytes, err := io.ReadAll(file)
 
 	if err != nil {
 		log.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -10,17 +10,22 @@ import (
 )
 
 func main() {
+	os.Exit(Run(os.Stdout, os.Args))
+}
+
+func Run(writer io.Writer, args []string) int {
 	var exitCode = 0
-	var writer io.Writer = os.Stdout
-	var flags = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	var flags = flag.NewFlagSet(args[0], flag.ExitOnError)
+	flag.CommandLine.SetOutput(writer)
 	var warn = flags.Bool("warn", false, "treat lint errors as warnings; write output to stdout and return exit code 0")
 	var debug = flags.Bool("debug", false, "write debug informations to stdout")
 	var pwd = flags.String("pwd", "", "relative path to the desired working directory")
 	var config_file = flags.String("config", "", "relative path to a config file")
 
-	if err := flags.Parse(os.Args[1:]); err != nil {
+	if err := flags.Parse(args[1:]); err != nil {
 		log.Fatal(err)
 	}
+
 	cwd, err := os.Getwd()
 	if err != nil {
 		log.Fatal(err)
@@ -57,7 +62,7 @@ func main() {
 
 	// no errors
 	if len(errors) == 0 {
-		os.Exit(exitCode)
+		return exitCode
 	}
 
 	if !*warn {
@@ -67,5 +72,5 @@ func main() {
 
 	linter.printErrors(writer, cwd, *pwd)
 
-	os.Exit(exitCode)
+	return exitCode
 }

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ func main() {
 	var flags = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	var warn = flags.Bool("warn", false, "treat lint errors as warnings; write output to stdout and return exit code 0")
 	var debug = flags.Bool("debug", false, "write debug informations to stdout")
-	var config_file = flags.String("config", ".ls-lint.yml", "relative path to a config file, its directory is the new root")
+	var config_file = flags.String("config", "", "relative path to a config file, its directory is the new root")
 
 	if err := flags.Parse(os.Args[1:]); err != nil {
 		log.Fatal(err)
@@ -38,7 +38,9 @@ func main() {
 		RWMutex:   new(sync.RWMutex),
 	}
 	
-	read_config_file(cwd, *config_file, config)
+	if err := read_config_file(cwd, *config_file, config); err != nil {
+		log.Fatal(err)
+	}
 
 	// runner
 	if err := linter.Run(filesystem, config, *debug, false); err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"testing"
+)
+
+func TestMainRun(t *testing.T) {
+	testSuite := []struct {
+		description string
+		args        []string
+		expect      int
+	}{
+		{
+			description: "Happy Path",
+			args:        []string{"ls-lint"},
+			expect:      0,
+		},
+	}
+
+	for _, testCase := range testSuite {
+		flag.Parse()
+		t.Run(testCase.description, func(t *testing.T) {
+			var output bytes.Buffer
+			var actual = Run(&output, testCase.args)
+			if actual != testCase.expect {
+				t.Errorf("got %d but expected %d", actual, testCase.expect)
+			}
+		})
+	}
+}

--- a/read_config_file.go
+++ b/read_config_file.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"gopkg.in/yaml.v3"
+	"io"
+	"log"
+	"os"
+	"path"
+)
+
+func read_config_file(cwd string, config_file string, config *Config) {
+
+	// if config_file is default, see if there's an `.ls-lint.yaml` file instead
+	if config_file == ".ls-lint.yml" {
+		files, err := os.ReadDir(cwd)
+		if err != nil {
+			log.Fatal(err)
+		}
+	
+		for _, file := range files {
+			match, match_err := path.Match(".ls-lint.y*ml", file.Name())
+			if match_err != nil {
+				log.Fatal(match_err)
+			}
+			if match {
+				config_file = file.Name()
+				break
+			}
+		}
+	}
+	// open config file
+	file, err := os.Open(config_file)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// close file
+	defer func() {
+		err = file.Close()
+
+		if err != nil {
+			log.Fatal(err)
+		}
+	}()
+
+	// read file
+	configBytes, err := io.ReadAll(file)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// to yaml
+	err = yaml.Unmarshal(configBytes, &config)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/read_config_file.go
+++ b/read_config_file.go
@@ -9,11 +9,11 @@ import (
 	"path"
 )
 
-func read_config_file(cwd string, config_file string, config *Config) error {
+func read_config_file(pwd string, config_file string, config *Config) error {
 
 	// if config_file is empty, check for both `.ls-lint.yml` and `.ls-lint.yaml`
 	if config_file == "" {
-		files, err := os.ReadDir(cwd)
+		files, err := os.ReadDir(pwd)
 		if err != nil {
 			return err
 		}

--- a/read_config_file_test.go
+++ b/read_config_file_test.go
@@ -3,25 +3,37 @@ package main
 import (
 	"log"
 	"os"
-	"reflect"
 	"sync"
 	"testing"
 )
 
 func TestReadConfigFile(t *testing.T) {
-	examples_config := &Config{
-		RWMutex: new(sync.RWMutex),
-	}
-	root_config := &Config {
-		RWMutex: new(sync.RWMutex),
-	}
 	cwd, err := os.Getwd()
 	if err != nil {
 		log.Fatal(err)
 	}
-	read_config_file(cwd, "./examples/nuxt-nuxt-js/.ls-lint.yml", examples_config)
-	read_config_file(cwd, ".ls-lint.yml", root_config)
-	if reflect.DeepEqual(examples_config.getLs(), root_config.getLs()) {
-		t.Errorf("Both configuration files have the same ls rules")
+
+	var tests = []*readConfigFileTestCase{
+		{name: "Default Case", cwd: cwd, config_file: ""},
+		{name: "Specify -config", cwd: cwd, config_file: "./examples/nuxt-nuxt-js/.ls-lint.yml"},
+		{name: "Non-existent cwd", cwd: "pathThat-should_never.exist/", config_file: ".ls-lint.yml", expected_error: "open pathThat-should_never.exist/: no such file or directory"},
+		{name: "Non-existing config_file", cwd: cwd, config_file: "non-existent-config.yml", expected_error: "open non-existent-config.yml: no such file or directory"},
+		{name: "Non-existent config_file without specifying -config", cwd: "./npm", config_file: "", expected_error: "no config file (.ls-lint.yml or .ls-lint.yaml) was found"},
+	}
+	
+	var i = 0
+	for _, test := range tests {
+		test_config := &Config{
+			RWMutex: new(sync.RWMutex),
+		}
+
+		err := read_config_file(test.cwd, test.config_file, test_config)
+
+		if err != nil && err.Error() != test.expected_error {
+			t.Errorf("Test %d failed (%s) with unmatched error - %s", i, test.name, err.Error())
+			return
+		}
+
+		i++
 	}
 }

--- a/read_config_file_test.go
+++ b/read_config_file_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"log"
+	"os"
+	"reflect"
+	"sync"
+	"testing"
+)
+
+func TestReadConfigFile(t *testing.T) {
+	examples_config := &Config{
+		RWMutex: new(sync.RWMutex),
+	}
+	root_config := &Config {
+		RWMutex: new(sync.RWMutex),
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err)
+	}
+	read_config_file(cwd, "./examples/nuxt-nuxt-js/.ls-lint.yml", examples_config)
+	read_config_file(cwd, ".ls-lint.yml", root_config)
+	if reflect.DeepEqual(examples_config.getLs(), root_config.getLs()) {
+		t.Errorf("Both configuration files have the same ls rules")
+	}
+}

--- a/read_config_file_test.go
+++ b/read_config_file_test.go
@@ -16,7 +16,7 @@ func TestReadConfigFile(t *testing.T) {
 	var tests = []*readConfigFileTestCase{
 		{name: "Default Case", cwd: cwd, config_file: ""},
 		{name: "Specify -config", cwd: cwd, config_file: "./examples/nuxt-nuxt-js/.ls-lint.yml"},
-		{name: "Non-existent cwd", cwd: "pathThat-should_never.exist/", config_file: ".ls-lint.yml", expected_error: "open pathThat-should_never.exist/: no such file or directory"},
+		{name: "Non-existent cwd without specifying -config", cwd: "pathThat-should_never.exist/", config_file: "", expected_error: "open pathThat-should_never.exist/: no such file or directory"},
 		{name: "Non-existing config_file", cwd: cwd, config_file: "non-existent-config.yml", expected_error: "open non-existent-config.yml: no such file or directory"},
 		{name: "Non-existent config_file without specifying -config", cwd: "./npm", config_file: "", expected_error: "no config file (.ls-lint.yml or .ls-lint.yaml) was found"},
 	}
@@ -31,6 +31,10 @@ func TestReadConfigFile(t *testing.T) {
 
 		if err != nil && err.Error() != test.expected_error {
 			t.Errorf("Test %d failed (%s) with unmatched error - %s", i, test.name, err.Error())
+			return
+		}
+		if err == nil && test.expected_error != "" {
+			t.Errorf("Test %d failed (%s) - No error when an error was expected - %s", i, test.name, test.expected_error)
 			return
 		}
 

--- a/test.go
+++ b/test.go
@@ -5,3 +5,10 @@ type ruleTest struct {
 	expected bool
 	err      error
 }
+
+type readConfigFileTestCase struct {
+	name					string
+	cwd						string
+	config_file 	string
+	expected_error string
+}


### PR DESCRIPTION
Should handle #29 if you want to use `.ls-lint.yaml` instead. Also allows for specifying a config file `ls-lint -config ./relative/path/to/config/.ls-lint.yaml`.

You can specify the relative path to a new working directory with `-pwd` flag. This could be useful for multi-language monorepos where projects have different directory naming conventions. `ls-lint -pwd ./relative/path -config ./relative/path/.ls-lint.yml`

Hyperfine performance results (2022/10/07 1:30 PM MT)

| build | results |
| ----- | ------ |
| master | `Time (mean ± σ):      85.0 ms ±   1.8 ms    [User: 48.4 ms, System: 32.4 ms]` | 
| this branch | `Time (mean ± σ):      84.6 ms ±   2.1 ms    [User: 48.4 ms, System: 32.2 ms]` |

Run on:
```
Hardware Overview:

      Model Name: MacBook Pro
      Model Identifier: MacBookPro16,1
      Processor Name: 6-Core Intel Core i7
      Processor Speed: 2.6 GHz
      Number of Processors: 1
      Total Number of Cores: 6
      L2 Cache: 768 KB
      L3 Cache: 6 MB
      Hyper-Threading Technology: Enabled
      Memory: 16 GB
```

I didn't see any contribution guidelines, so let me know if you'd like me to do something else.