### PR TITLE
feat: add glob ignore index

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -39,4 +39,4 @@ jobs:
           credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
       - run: bazel run --remote_cache=$GOOGLE_BUCKET --google_default_credentials //deployments/github:ls_lint_publish
       - run: bazel build --remote_cache=$GOOGLE_BUCKET --google_default_credentials //deployments/npm:ls_lint
-      - run: (cd bazel-bin/deployments/npm/ls_lint && NPM_CONFIG_USERCONFIG=${GITHUB_WORKSPACE}/deployments/npm/.npmrc npm publish --no-git-checks) # workaround: https://bazelbuild.slack.com/archives/CEZUUKQ6P/p1667995025343689 # --dry-run --tag beta
+      - run: (cd bazel-bin/deployments/npm/ls_lint && NPM_CONFIG_USERCONFIG=${GITHUB_WORKSPACE}/deployments/npm/.npmrc npm publish --no-git-checks --tag beta) # workaround: https://bazelbuild.slack.com/archives/CEZUUKQ6P/p1667995025343689 # --dry-run --tag beta

--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -9,11 +9,8 @@ ls:
 
 ignore:
   - .git
-  - .idea
   - .github
+  - .idea
   - genhtml
-  - bazel-bin
-  - bazel-out
-  - bazel-ls-lint
-  - bazel-testlogs
+  - bazel-*
   - deployments/npm/pnpm-lock.yaml

--- a/deployments/github/github.sh
+++ b/deployments/github/github.sh
@@ -4,4 +4,4 @@ set -euo pipefail
 gh=$1
 github_files=$2
 
-$gh release create --generate-notes --latest ${STABLE_GIT_TAG} $github_files
+$gh release create --generate-notes --latest ${STABLE_GIT_TAG} --draft $github_files

--- a/internal/config/BUILD.bazel
+++ b/internal/config/BUILD.bazel
@@ -5,10 +5,7 @@ go_library(
     srcs = ["config.go"],
     importpath = "github.com/loeffel-io/ls-lint/v2/internal/config",
     visibility = ["//:__subpackages__"],
-    deps = [
-        "//internal/rule",
-        "@com_github_bmatcuk_doublestar_v4//:doublestar",
-    ],
+    deps = ["//internal/rule"],
 )
 
 go_test(

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,9 +2,7 @@ package config
 
 import (
 	"fmt"
-	"github.com/bmatcuk/doublestar/v4"
 	"github.com/loeffel-io/ls-lint/v2/internal/rule"
-	"io/fs"
 	"reflect"
 	"strings"
 	"sync"
@@ -91,42 +89,6 @@ func (config *Config) GetIndex(list Ls) (RuleIndex, error) {
 	}
 
 	return index, nil
-}
-
-func (config *Config) GlobIndex(filesystem fs.FS, index RuleIndex) (err error) {
-	for key, value := range index {
-		var matches []string
-
-		if !strings.ContainsAny(key, "*{}") {
-			continue
-		}
-
-		if matches, err = doublestar.Glob(filesystem, key); err != nil {
-			return err
-		}
-
-		if len(matches) == 0 {
-			delete(index, key)
-			continue
-		}
-
-		for _, match := range matches {
-			var matchInfo fs.FileInfo
-
-			if matchInfo, err = fs.Stat(filesystem, match); err != nil {
-				return err
-			}
-
-			if !matchInfo.IsDir() {
-				continue
-			}
-
-			index[match] = value
-			delete(index, key)
-		}
-	}
-
-	return nil
 }
 
 func (config *Config) walkIndex(index RuleIndex, key string, list Ls) error {

--- a/internal/glob/BUILD.bazel
+++ b/internal/glob/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "glob",
+    srcs = ["glob.go"],
+    importpath = "github.com/loeffel-io/ls-lint/v2/internal/glob",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/rule",
+        "@com_github_bmatcuk_doublestar_v4//:doublestar",
+    ],
+)

--- a/internal/glob/glob.go
+++ b/internal/glob/glob.go
@@ -1,0 +1,44 @@
+package glob
+
+import (
+	"github.com/bmatcuk/doublestar/v4"
+	"github.com/loeffel-io/ls-lint/v2/internal/rule"
+	"io/fs"
+	"strings"
+)
+
+func Index[IndexValue bool | map[string][]rule.Rule](filesystem fs.FS, index map[string]IndexValue, files bool) (err error) {
+	for key, value := range index {
+		var matches []string
+
+		if !strings.ContainsAny(key, "*{}") {
+			continue
+		}
+
+		if matches, err = doublestar.Glob(filesystem, key); err != nil {
+			return err
+		}
+
+		if len(matches) == 0 {
+			delete(index, key)
+			continue
+		}
+
+		for _, match := range matches {
+			var matchInfo fs.FileInfo
+
+			if matchInfo, err = fs.Stat(filesystem, match); err != nil {
+				return err
+			}
+
+			if !files && !matchInfo.IsDir() {
+				continue
+			}
+
+			index[match] = value
+			delete(index, key)
+		}
+	}
+
+	return nil
+}

--- a/internal/linter/BUILD.bazel
+++ b/internal/linter/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//internal/config",
         "//internal/debug",
+        "//internal/glob",
         "//internal/rule",
         "@org_golang_x_sync//errgroup",
     ],

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/loeffel-io/ls-lint/v2/internal/config"
 	"github.com/loeffel-io/ls-lint/v2/internal/debug"
+	"github.com/loeffel-io/ls-lint/v2/internal/glob"
 	"github.com/loeffel-io/ls-lint/v2/internal/rule"
 	"golang.org/x/sync/errgroup"
 	"io/fs"
@@ -173,7 +174,12 @@ func (linter *Linter) Run(filesystem fs.FS, debug bool, statistics bool) (err er
 	}
 
 	// glob index
-	if err = linter.config.GlobIndex(filesystem, index); err != nil {
+	if err = glob.Index(filesystem, index, false); err != nil {
+		return err
+	}
+
+	// glob ignore index
+	if err = glob.Index(filesystem, ignoreIndex, true); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
follow #76 
ref #36 

adds glob support for `ignore`

example: 

```yaml
ignore: 
    - '**/*.png' 
    - '**/{a,b}/*.js'
    - bazel-*
```