### PR TITLE
feat: merge

### DIFF
--- a/cmd/ls_lint/BUILD.bazel
+++ b/cmd/ls_lint/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     deps = [
         "//internal/config",
         "//internal/debug",
+        "//internal/flag",
         "//internal/linter",
         "//internal/rule",
         "@in_gopkg_yaml_v3//:yaml_v3",

--- a/internal/debug/statistic.go
+++ b/internal/debug/statistic.go
@@ -16,6 +16,7 @@ type Statistic struct {
 
 func NewStatistic() *Statistic {
 	return &Statistic{
+		Start:   time.Now(),
 		RWMutex: new(sync.RWMutex),
 	}
 }

--- a/internal/flag/BUILD.bazel
+++ b/internal/flag/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "flag",
+    srcs = ["config.go"],
+    importpath = "github.com/loeffel-io/ls-lint/v2/internal/flag",
+    visibility = ["//:__subpackages__"],
+)

--- a/internal/flag/config.go
+++ b/internal/flag/config.go
@@ -1,0 +1,14 @@
+package flag
+
+import "strings"
+
+type Config []string
+
+func (config *Config) String() string {
+	return strings.Join(*config, ",")
+}
+
+func (config *Config) Set(value string) error {
+	*config = append(*config, value)
+	return nil
+}

--- a/internal/glob/glob.go
+++ b/internal/glob/glob.go
@@ -35,7 +35,10 @@ func Index[IndexValue bool | map[string][]rule.Rule](filesystem fs.FS, index map
 				continue
 			}
 
-			index[match] = value
+			if _, ok := index[match]; !ok {
+				index[match] = value
+			}
+
 			delete(index, key)
 		}
 	}

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -292,7 +292,7 @@ func TestLinterRun(t *testing.T) {
 	for _, test := range tests {
 		fmt.Printf("Run test %d (%s)\n", i, test.description)
 
-		var err = test.linter.Run(test.filesystem, true, true)
+		var err = test.linter.Run(test.filesystem, true)
 
 		if !errors.Is(err, test.expectedErr) {
 			t.Errorf("Test %d (%s) failed with unmatched error value - %v", i, test.description, err)

--- a/internal/rule/camelcase.go
+++ b/internal/rule/camelcase.go
@@ -28,6 +28,10 @@ func (rule *CamelCase) SetParameters(params []string) error {
 	return nil
 }
 
+func (rule *CamelCase) GetParameters() []string {
+	return nil
+}
+
 // Validate checks if string is camel case
 // false if rune is no letter and no digit
 func (rule *CamelCase) Validate(value string) (bool, error) {

--- a/internal/rule/kebabcase.go
+++ b/internal/rule/kebabcase.go
@@ -28,6 +28,10 @@ func (rule *KebabCase) SetParameters(params []string) error {
 	return nil
 }
 
+func (rule *KebabCase) GetParameters() []string {
+	return nil
+}
+
 // Validate checks if string is kebab case
 // false if rune is no lowercase letter, digit or -
 func (rule *KebabCase) Validate(value string) (bool, error) {

--- a/internal/rule/lowercase.go
+++ b/internal/rule/lowercase.go
@@ -28,6 +28,10 @@ func (rule *Lowercase) SetParameters(params []string) error {
 	return nil
 }
 
+func (rule *Lowercase) GetParameters() []string {
+	return nil
+}
+
 // Validate checks if every letter is lower
 func (rule *Lowercase) Validate(value string) (bool, error) {
 	for _, c := range value {

--- a/internal/rule/pascalcase.go
+++ b/internal/rule/pascalcase.go
@@ -28,6 +28,10 @@ func (rule *PascalCase) SetParameters(params []string) error {
 	return nil
 }
 
+func (rule *PascalCase) GetParameters() []string {
+	return nil
+}
+
 // Validate checks if string is pascal case
 // false if rune is no letter and no digit
 // false if first rune is not upper

--- a/internal/rule/pointcase.go
+++ b/internal/rule/pointcase.go
@@ -28,6 +28,10 @@ func (rule *PointCase) SetParameters(params []string) error {
 	return nil
 }
 
+func (rule *PointCase) GetParameters() []string {
+	return nil
+}
+
 // Validate checks if string is "point case"
 // false if rune is no lowercase letter, digit or .
 func (rule *PointCase) Validate(value string) (bool, error) {

--- a/internal/rule/regex.go
+++ b/internal/rule/regex.go
@@ -43,6 +43,10 @@ func (rule *Regex) SetParameters(params []string) error {
 	return nil
 }
 
+func (rule *Regex) GetParameters() []string {
+	return []string{rule.RegexPattern}
+}
+
 // Validate checks if full string matches regex
 func (rule *Regex) Validate(value string) (bool, error) {
 	return regexp.MatchString(fmt.Sprintf("^%s$", rule.getRegexPattern()), value)

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -39,6 +39,7 @@ type Rule interface {
 	Init() Rule
 	GetName() string
 	SetParameters(params []string) error
+	GetParameters() []string
 	Validate(value string) (bool, error)
 	GetErrorMessage() string
 }

--- a/internal/rule/screamingsnakecase.go
+++ b/internal/rule/screamingsnakecase.go
@@ -28,6 +28,10 @@ func (rule *ScreamingSnakeCase) SetParameters(params []string) error {
 	return nil
 }
 
+func (rule *ScreamingSnakeCase) GetParameters() []string {
+	return nil
+}
+
 // Validate checks if string is screaming sneak case
 // false if rune is no uppercase letter, digit or _
 func (rule *ScreamingSnakeCase) Validate(value string) (bool, error) {

--- a/internal/rule/snakecase.go
+++ b/internal/rule/snakecase.go
@@ -28,6 +28,10 @@ func (rule *SnakeCase) SetParameters(params []string) error {
 	return nil
 }
 
+func (rule *SnakeCase) GetParameters() []string {
+	return nil
+}
+
 // Validate checks if string is sneak case
 // false if rune is no lowercase letter, digit or _
 func (rule *SnakeCase) Validate(value string) (bool, error) {

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -7,6 +7,7 @@ def go_repositories():
         sum = "h1:HTuxyug8GyFbRkrffIpzNCSK4luc0TY3wzXvzIZhEXc=",
         version = "v4.6.0",
     )
+
     go_repository(
         name = "in_gopkg_check_v1",
         importpath = "gopkg.in/check.v1",
@@ -19,6 +20,7 @@ def go_repositories():
         sum = "h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=",
         version = "v3.0.1",
     )
+
     go_repository(
         name = "org_golang_x_sync",
         importpath = "golang.org/x/sync",


### PR DESCRIPTION
enables multiple extending configurations, new debug output and overwriting glob matched directory rules: 

```bash
=============================
ls index
-----------------------------
.: .go: snakecase .dir: snakecase .bzl: snakecase .sh: snakecase .bazel: screamingsnakecase .yaml: snakecase .js: snakecase
src/test: .js: screamingsnakecase .html: regex:[a-z0-9]+
src/go: .go: pascalcase
-----------------------------
ignore index
-----------------------------
.git
.idea
bazel-ge
deployments/npm/pnpm-lock.yaml
bazel-out
bazel-testlogs
.github
bazel-ls-lint
genhtml
bazel-bin
-----------------------------
lint
-----------------------------
lint dir: .
lint file: .bazelrc
lint file: .bazelversion
skip dir: .git
skip dir: .github
lint file: .gitignore
skip dir: .idea
lint file: .ls-lint-2.yml
lint file: .ls-lint.yml
lint file: BUILD.bazel
lint file: LICENSE
lint file: README.md
lint file: WORKSPACE
lint dir: assets
lint dir: assets/logo
lint file: assets/logo/ls-lint.png
skip file: bazel-bin
skip file: bazel-ls-lint
skip file: bazel-out
skip file: bazel-testlogs
lint dir: cmd
lint dir: cmd/ls_lint
lint file: cmd/ls_lint/BUILD.bazel
lint file: cmd/ls_lint/main.go
lint file: cmd/ls_lint/target.bzl
lint dir: deployments
lint dir: deployments/docker
lint file: deployments/docker/Dockerfile
lint file: deployments/docker/Dockerfile.arm64
lint file: deployments/docker/manifest.tmpl
lint dir: deployments/github
lint file: deployments/github/BUILD.bazel
lint file: deployments/github/github.sh
lint dir: deployments/npm
lint file: deployments/npm/.npmrc
lint file: deployments/npm/BUILD.bazel
lint dir: deployments/npm/bin
lint file: deployments/npm/bin/cli.js
lint file: deployments/npm/package.json
skip file: deployments/npm/pnpm-lock.yaml
lint dir: examples
lint dir: examples/nuxt_nuxt_js
lint file: examples/nuxt_nuxt_js/.ls-lint.yml
lint file: go.mod
lint file: go.sum
lint dir: internal
lint dir: internal/config
lint file: internal/config/BUILD.bazel
lint file: internal/config/config.go
lint file: internal/config/config_test.go
lint dir: internal/debug
lint file: internal/debug/BUILD.bazel
lint file: internal/debug/statistic.go
lint dir: internal/flag
lint file: internal/flag/BUILD.bazel
lint file: internal/flag/config.go
lint dir: internal/glob
lint file: internal/glob/BUILD.bazel
lint file: internal/glob/glob.go
lint dir: internal/linter
lint file: internal/linter/BUILD.bazel
lint file: internal/linter/linter.go
lint file: internal/linter/linter_test.go
lint dir: internal/rule
lint file: internal/rule/BUILD.bazel
lint file: internal/rule/camelcase.go
lint file: internal/rule/camelcase_test.go
lint file: internal/rule/error.go
lint file: internal/rule/kebabcase.go
lint file: internal/rule/kebabcase_test.go
lint file: internal/rule/lowercase.go
lint file: internal/rule/lowercase_test.go
lint file: internal/rule/pascalcase.go
lint file: internal/rule/pascalcase_test.go
lint file: internal/rule/pointcase.go
lint file: internal/rule/pointcase_test.go
lint file: internal/rule/regex.go
lint file: internal/rule/regex_test.go
lint file: internal/rule/rule.go
lint file: internal/rule/rule_test.go
lint file: internal/rule/screamingsnakecase.go
lint file: internal/rule/screamingsnakecase_test.go
lint file: internal/rule/snakecase.go
lint file: internal/rule/snakecase_test.go
lint file: renovate.json
lint file: repositories.bzl
lint dir: scripts
lint dir: scripts/bazel
lint file: scripts/bazel/workspace_status.sh
lint dir: src
lint dir: src/go
lint dir: src/test
lint file: src/test/test.js
-----------------------------
statistics
-----------------------------
time: 1 ms
files: 61
file skips: 5
dirs: 24
dir skips: 3
=============================
```