### PR TITLE
#201: implement disallow rule

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -144,6 +144,8 @@ func (config *Config) copyRule(r rule.Rule) rule.Rule {
 	switch r.GetName() {
 	case "regex":
 		return new(rule.Regex).Init()
+	case "disallow":
+		return new(rule.Disallow).Init()
 	}
 
 	return r

--- a/internal/rule/BUILD.bazel
+++ b/internal/rule/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "rule.go",
         "screamingsnakecase.go",
         "snakecase.go",
+        "disallow.go",
     ],
     importpath = "github.com/loeffel-io/ls-lint/v2/internal/rule",
     visibility = ["//:__subpackages__"],
@@ -30,6 +31,7 @@ go_test(
         "rule_test.go",
         "screamingsnakecase_test.go",
         "snakecase_test.go",
+        "disallow_test.go",
     ],
     embed = [":rule"],
 )

--- a/internal/rule/disallow.go
+++ b/internal/rule/disallow.go
@@ -1,0 +1,66 @@
+package rule
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+)
+
+type Disallow struct {
+	Name    string
+	Message string
+	*sync.RWMutex
+}
+
+func (rule *Disallow) Init() Rule {
+	rule.Name = "disallow"
+	rule.RWMutex = new(sync.RWMutex)
+
+	return rule
+}
+
+func (rule *Disallow) GetName() string {
+	rule.Lock()
+	defer rule.Unlock()
+
+	return rule.Name
+}
+
+func (rule *Disallow) SetParameters(params []string) error {
+	rule.Lock()
+	defer rule.Unlock()
+
+	if len(params) > 0 && params[0] != "" {
+		rule.Message = strings.TrimSpace(params[0])
+	} else {
+		rule.Message = ""
+	}
+	return nil
+}
+
+func (rule *Disallow) GetParameters() []string {
+	return []string{rule.Message}
+}
+
+// Validate always returns false
+// Any string that matches fails validation.
+func (rule *Disallow) Validate(string) (bool, error) {
+	return false, nil
+}
+
+func (rule *Disallow) getMessage() string {
+	rule.RLock()
+	defer rule.RUnlock()
+
+	return rule.Message
+}
+
+func (rule *Disallow) GetErrorMessage() string {
+	var disallowMessage string
+	if rule.getMessage() != "" {
+		disallowMessage = fmt.Sprintf(" (%s)", rule.getMessage())
+	} else {
+		disallowMessage = ""
+	}
+	return fmt.Sprintf("%s%s", rule.GetName(), disallowMessage)
+}

--- a/internal/rule/disallow_test.go
+++ b/internal/rule/disallow_test.go
@@ -1,0 +1,35 @@
+package rule
+
+import "testing"
+
+func TestDisallow(t *testing.T) {
+	var rule = new(Disallow).Init()
+
+	var tests = []*ruleTest{
+		{value: "camelCase", expected: false, err: nil},
+		{value: "PascalCase", expected: false, err: nil},
+		{value: "kebab-case", expected: false, err: nil},
+		{value: "lowercase", expected: false, err: nil},
+		{value: "point.case", expected: false, err: nil},
+		{value: "snake_case", expected: false, err: nil},
+		{value: "SCREAMING_SNAKE_CASE", expected: false, err: nil},
+		{value: "literally anything at all", expected: false, err: nil},
+	}
+
+	var i = 0
+	for _, test := range tests {
+		res, err := rule.Validate(test.value)
+
+		if err != nil && err != test.err {
+			t.Errorf("Test %d failed with unmatched error - %s", i, err.Error())
+			return
+		}
+
+		if res != test.expected {
+			t.Errorf("Test %d failed with unmatched return value - %+v", i, res)
+			return
+		}
+
+		i++
+	}
+}

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -10,6 +10,7 @@ var RulesIndex = map[string]Rule{
 	"screamingsnakecase": new(ScreamingSnakeCase).Init(),
 	"kebabcase":          new(KebabCase).Init(),
 	"pointcase":          new(PointCase).Init(),
+	"disallow":           new(Disallow).Init(),
 }
 
 var Rules = map[string]Rule{
@@ -33,6 +34,8 @@ var Rules = map[string]Rule{
 
 	"pointcase":  RulesIndex["pointcase"],
 	"point.case": RulesIndex["pointcase"],
+
+	"disallow": RulesIndex["disallow"],
 }
 
 type Rule interface {


### PR DESCRIPTION
Example implementation for a disallow rule as I mentioned in #201 if the maintainers are interested in the feature. Open to all feedback.

I have not written Go before, so I apologize if there are beginner mistakes, but I added testing where possible. 

I compiled and installed it locally and here is an example usage and the results: 


```yml
ls:
  .blocked: disallow
  .no: disallow:use something else
  .actually.no: disallow:no

ignore:
  - node_modules
```

will result in (given matches for each)

```
2024/02/28 00:35:55 src/utils/fil3.blocked failed for rules: disallow
2024/02/28 00:35:55 src/utils/file2.no failed for rules: disallow (use something else)
2024/02/28 00:35:55 src/utils/file4.maybe.actually.no failed for rules: disallow (no)
```

