### PR TITLE
add new rules for ease of use: pascalcaseacronym, uppercasedigit

### DIFF
--- a/internal/rule/pascalcaseacronym.go
+++ b/internal/rule/pascalcaseacronym.go
@@ -1,0 +1,73 @@
+package rule
+
+import (
+	"sync"
+	"unicode"
+)
+
+type PascalCaseAcronym struct {
+	Name string
+	*sync.RWMutex
+}
+
+func (rule *PascalCaseAcronym) Init() Rule {
+	rule.Name = "pascalcaseacronym"
+	rule.RWMutex = new(sync.RWMutex)
+
+	return rule
+}
+
+func (rule *PascalCaseAcronym) GetName() string {
+	rule.Lock()
+	defer rule.Unlock()
+
+	return rule.Name
+}
+
+func (rule *PascalCaseAcronym) SetParameters([]string) error {
+	return nil
+}
+
+func (rule *PascalCaseAcronym) GetParameters() []string {
+	return nil
+}
+
+// Validate checks if string is pascal case
+// false if rune is no letter and no digit
+// false if first rune is not upper
+// allows up to five consecutive upper letters
+// allow cases like CTOClown.go or NASAImages/
+func (rule *PascalCaseAcronym) Validate(value string) (bool, error) {
+	upperStreak := 0
+
+	for i, c := range value {
+		// must be letter or digit
+		if !unicode.IsLetter(c) && !unicode.IsDigit(c) {
+			return false, nil
+		}
+
+		// first rune must be upper
+		if i == 0 && unicode.IsLower(c) {
+			return false, nil
+		}
+
+		if unicode.IsUpper(c) {
+			upperStreak++
+			if i == 0 {
+				continue
+			}
+
+			if upperStreak > 5 {
+				return false, nil
+			}
+		} else {
+			upperStreak = 0
+		}
+	}
+
+	return true, nil
+}
+
+func (rule *PascalCaseAcronym) GetErrorMessage() string {
+	return rule.GetName()
+}

--- a/internal/rule/pascalcaseacronym_test.go
+++ b/internal/rule/pascalcaseacronym_test.go
@@ -2,8 +2,8 @@ package rule
 
 import "testing"
 
-func TestPascalCase(t *testing.T) {
-	var rule = new(PascalCase).Init()
+func TestPascalCaseAbbrev(t *testing.T) {
+	var rule = new(PascalCaseAcronym).Init()
 
 	var tests = []*ruleTest{
 		{value: "pascal", expected: false, err: nil},
@@ -13,13 +13,14 @@ func TestPascalCase(t *testing.T) {
 		{value: "PascalCase", expected: true, err: nil},
 		{value: "Pascal1Case", expected: true, err: nil},
 		{value: "PascalVCase", expected: true, err: nil},
+		{value: "PPPascalCCCaseNN", expected: true, err: nil}, // that's on one's conscience
+		{value: "NASAImages", expected: true, err: nil},
+		{value: "NASVAIImages", expected: false, err: nil},
 		{value: "PascalCaseForever", expected: true, err: nil},
 		{value: "PASCALCASE", expected: false, err: nil},
 		{value: "pascal_case", expected: false, err: nil},
 		{value: "pascal.case", expected: false, err: nil},
 		{value: "pascal-case", expected: false, err: nil},
-		{value: "NASAImages", expected: false, err: nil},
-		{value: "SaySEO", expected: false, err: nil},
 	}
 
 	var i = 0

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -6,21 +6,29 @@ var RulesIndex = map[string]Rule{
 
 	"camelcase":          new(CamelCase).Init(),
 	"pascalcase":         new(PascalCase).Init(),
+	"pascalcaseacronym":  new(PascalCaseAcronym).Init(),
 	"snakecase":          new(SnakeCase).Init(),
 	"screamingsnakecase": new(ScreamingSnakeCase).Init(),
 	"kebabcase":          new(KebabCase).Init(),
 	"pointcase":          new(PointCase).Init(),
+	"uppercasedigit":     new(UppercaseDigit).Init(),
 }
 
 var Rules = map[string]Rule{
-	"lowercase": RulesIndex["lowercase"],
-	"regex":     RulesIndex["regex"],
+	"lowercase":      RulesIndex["lowercase"],
+	"uppercasedigit": RulesIndex["uppercasedigit"],
+	"UppercaseDigit": RulesIndex["uppercasedigit"],
+
+	"regex": RulesIndex["regex"],
 
 	"camelcase": RulesIndex["camelcase"],
 	"camelCase": RulesIndex["camelcase"],
 
 	"pascalcase": RulesIndex["pascalcase"],
 	"PascalCase": RulesIndex["pascalcase"],
+
+	"pascalcaseacronym": RulesIndex["pascalcaseacronym"],
+	"PascalCaseAcronym": RulesIndex["pascalcaseacronym"],
 
 	"snakecase":  RulesIndex["snakecase"],
 	"snake_case": RulesIndex["snakecase"],

--- a/internal/rule/uppercasedigit.go
+++ b/internal/rule/uppercasedigit.go
@@ -1,0 +1,52 @@
+package rule
+
+import (
+	"sync"
+	"unicode"
+)
+
+type UppercaseDigit struct {
+	Name string
+	*sync.RWMutex
+}
+
+func (rule *UppercaseDigit) Init() Rule {
+	rule.Name = "uppercasedigit"
+	rule.RWMutex = new(sync.RWMutex)
+
+	return rule
+}
+
+func (rule *UppercaseDigit) GetName() string {
+	rule.Lock()
+	defer rule.Unlock()
+
+	return rule.Name
+}
+
+func (rule *UppercaseDigit) SetParameters([]string) error {
+	return nil
+}
+
+func (rule *UppercaseDigit) GetParameters() []string {
+	return nil
+}
+
+// Validate checks if string is all uppercase or digit
+// false if rune is no uppercase letter or digit
+func (rule *UppercaseDigit) Validate(value string) (bool, error) {
+	for _, c := range value {
+		if unicode.IsDigit(c) {
+			continue
+		}
+		if !unicode.IsLetter(c) || !unicode.IsUpper(c) {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func (rule *UppercaseDigit) GetErrorMessage() string {
+	return rule.GetName()
+}

--- a/internal/rule/uppercasedigit_test.go
+++ b/internal/rule/uppercasedigit_test.go
@@ -1,0 +1,43 @@
+package rule
+
+import (
+	"testing"
+)
+
+func TestUpperCaseOrDigit(t *testing.T) {
+	var rule = new(UppercaseDigit).Init()
+
+	var tests = []*ruleTest{
+		{value: "ALLCAPS", expected: true, err: nil},
+		{value: "ALLCAPS007", expected: true, err: nil},
+		{value: "VIN1234567", expected: true, err: nil},
+		{value: "tooshortbud", expected: false, err: nil},
+		{value: "SNEAKCase", expected: false, err: nil},
+		{value: "Sneakcase", expected: false, err: nil},
+		{value: "SneakCase", expected: false, err: nil},
+		{value: "SNAKE_CASE", expected: false, err: nil},
+		{value: "SNAKE_123_CASE", expected: false, err: nil},
+		{value: "SNAKE_CASE_TEST", expected: false, err: nil},
+		{value: "snake.case.test", expected: false, err: nil},
+		{value: "SNAKE.CASE.TEST", expected: false, err: nil},
+		{value: "snake-case-test", expected: false, err: nil},
+		{value: "SNAKE-CASE-TEST", expected: false, err: nil},
+	}
+
+	var i = 0
+	for _, test := range tests {
+		res, err := rule.Validate(test.value)
+
+		if err != nil && err != test.err {
+			t.Errorf("Test %d failed with unmatched error - %s", i, err.Error())
+			return
+		}
+
+		if res != test.expected {
+			t.Errorf("Test %d failed with unmatched return value - %+v", i, res)
+			return
+		}
+
+		i++
+	}
+}


### PR DESCRIPTION
Hello. 
Proposing two tiny rules.

PascalCaseAcronym that allows for up to five consecutive uppercase letters. 
It (not directly perhaps) has been sought after not by me only but and [here](https://github.com/loeffel-io/ls-lint/issues/67) and [there](https://github.com/loeffel-io/ls-lint/issues/167) as well.

UppercaseDigit that would help with stuff like VINs etc. ([A-Z0-9]+ is not sufficient as I have cyryllic symbols, not elegant)

I thank you for your work, tool's cool.
Whatever your word's on the pull cap.