### PR TITLE
refactor: use if-else instead of switch for bool

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -102,12 +102,11 @@ func (config *Config) walkIndex(index RuleIndex, key string, list Ls) error {
 		}
 
 		if reflect.TypeOf(v).Kind() == reflect.Map {
-			switch key == "" {
-			case true:
+			if key == "" {
 				if err := config.walkIndex(index, k, v.(Ls)); err != nil {
 					return err
 				}
-			case false:
+			} else {
 				var keyCombination = fmt.Sprintf("%s%s%s", key, sep, k)
 				if err := config.walkIndex(index, keyCombination, v.(Ls)); err != nil {
 					return err

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -203,10 +203,9 @@ func (linter *Linter) Run(filesystem fs.FS, debug bool) (err error) {
 	if debug {
 		fmt.Printf("=============================\nls index\n-----------------------------\n")
 		for path, pathIndex := range index {
-			switch path == "" {
-			case true:
+			if path == "" {
 				fmt.Printf(".:")
-			case false:
+			} else {
 				fmt.Printf("%s:", path)
 			}
 


### PR DESCRIPTION
The PR refactors code from `switch B { case true: ... case false: ...}` to `if B {...} else {...}`, where `B` is simply boolean `true` or `false`.