### PR TITLE
feat: regex substitutions

### DIFF
--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -94,7 +94,7 @@ func (linter *Linter) validateDir(index config.RuleIndex, path string, validate 
 				return nil
 			}
 
-			valid, err := ruleDir.Validate(basename, "", ruleDir.GetName() != "exists")
+			valid, err := ruleDir.Validate(basename, pathDir, ruleDir.GetName() != "exists")
 			if err != nil {
 				return err
 			}
@@ -177,7 +177,7 @@ func (linter *Linter) validateFile(index config.RuleIndex, path string, validate
 						return nil
 					}
 
-					valid, err := ruleFile.Validate(withoutExt, "", ruleFile.GetName() != "exists")
+					valid, err := ruleFile.Validate(withoutExt, pathDir, ruleFile.GetName() != "exists")
 					if err != nil {
 						return err
 					}

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -94,7 +94,7 @@ func (linter *Linter) validateDir(index config.RuleIndex, path string, validate 
 				return nil
 			}
 
-			valid, err := ruleDir.Validate(basename, ruleDir.GetName() != "exists")
+			valid, err := ruleDir.Validate(basename, "", ruleDir.GetName() != "exists")
 			if err != nil {
 				return err
 			}
@@ -177,7 +177,7 @@ func (linter *Linter) validateFile(index config.RuleIndex, path string, validate
 						return nil
 					}
 
-					valid, err := ruleFile.Validate(withoutExt, ruleFile.GetName() != "exists")
+					valid, err := ruleFile.Validate(withoutExt, "", ruleFile.GetName() != "exists")
 					if err != nil {
 						return err
 					}
@@ -372,7 +372,7 @@ func (linter *Linter) Run(filesystem fs.FS, paths map[string]struct{}, debug boo
 				}
 
 				var valid bool
-				if valid, err = r.Validate("", true); err != nil {
+				if valid, err = r.Validate("", "", true); err != nil {
 					return err
 				}
 

--- a/internal/rule/camelcase.go
+++ b/internal/rule/camelcase.go
@@ -43,7 +43,7 @@ func (rule *CamelCase) GetExclusive() bool {
 
 // Validate checks if string is camel case
 // false if rune is no letter and no digit
-func (rule *CamelCase) Validate(value string, fail bool) (bool, error) {
+func (rule *CamelCase) Validate(value string, _ string, _ bool) (bool, error) {
 	for i, c := range value {
 		// must be letter or digit
 		if !unicode.IsLetter(c) && !unicode.IsDigit(c) {

--- a/internal/rule/camelcase_test.go
+++ b/internal/rule/camelcase_test.go
@@ -26,7 +26,7 @@ func TestCamelCase(t *testing.T) {
 
 	i := 0
 	for _, test := range tests {
-		res, err := rule.Validate(test.value, true)
+		res, err := rule.Validate(test.value, "", true)
 
 		if !errors.Is(err, test.err) {
 			t.Errorf("Test %d failed with unmatched error - %e", i, err)

--- a/internal/rule/exists.go
+++ b/internal/rule/exists.go
@@ -101,7 +101,7 @@ func (rule *Exists) GetExclusive() bool {
 	return rule.exclusive
 }
 
-func (rule *Exists) Validate(value string, fail bool) (bool, error) {
+func (rule *Exists) Validate(value string, _ string, fail bool) (bool, error) {
 	if !fail {
 		rule.incrementCount()
 		return true, nil

--- a/internal/rule/exists_test.go
+++ b/internal/rule/exists_test.go
@@ -59,7 +59,7 @@ func TestExists_Validate(t *testing.T) {
 
 	i := 0
 	for _, test := range tests {
-		valid, err := test.rule.Validate("", test.fail)
+		valid, err := test.rule.Validate("", "", test.fail)
 
 		if !errors.Is(err, test.err) {
 			t.Errorf("Test %d failed with unmatched error - %e", i, err)

--- a/internal/rule/kebabcase.go
+++ b/internal/rule/kebabcase.go
@@ -43,7 +43,7 @@ func (rule *KebabCase) GetExclusive() bool {
 
 // Validate checks if string is kebab case
 // false if rune is no lowercase letter, digit or -
-func (rule *KebabCase) Validate(value string, fail bool) (bool, error) {
+func (rule *KebabCase) Validate(value string, _ string, _ bool) (bool, error) {
 	for _, c := range value {
 		if c == 45 || unicode.IsDigit(c) { // 45 => -
 			continue

--- a/internal/rule/kebabcase_test.go
+++ b/internal/rule/kebabcase_test.go
@@ -24,7 +24,7 @@ func TestKebabCase(t *testing.T) {
 
 	i := 0
 	for _, test := range tests {
-		res, err := rule.Validate(test.value, true)
+		res, err := rule.Validate(test.value, "", true)
 
 		if !errors.Is(err, test.err) {
 			t.Errorf("Test %d failed with unmatched error - %e", i, err)

--- a/internal/rule/lowercase.go
+++ b/internal/rule/lowercase.go
@@ -42,7 +42,7 @@ func (rule *Lowercase) GetExclusive() bool {
 }
 
 // Validate checks if every letter is lower
-func (rule *Lowercase) Validate(value string, fail bool) (bool, error) {
+func (rule *Lowercase) Validate(value string, _ string, _ bool) (bool, error) {
 	for _, c := range value {
 		if unicode.IsLetter(c) && !unicode.IsLower(c) {
 			return false, nil

--- a/internal/rule/lowercase_test.go
+++ b/internal/rule/lowercase_test.go
@@ -16,7 +16,7 @@ func TestLowercase(t *testing.T) {
 
 	i := 0
 	for _, test := range tests {
-		res, err := rule.Validate(test.value, true)
+		res, err := rule.Validate(test.value, "", true)
 
 		if !errors.Is(err, test.err) {
 			t.Errorf("Test %d failed with unmatched error - %e", i, err)

--- a/internal/rule/pascalcase.go
+++ b/internal/rule/pascalcase.go
@@ -44,7 +44,7 @@ func (rule *PascalCase) GetExclusive() bool {
 // Validate checks if string is pascal case
 // false if rune is no letter and no digit
 // false if first rune is not upper
-func (rule *PascalCase) Validate(value string, fail bool) (bool, error) {
+func (rule *PascalCase) Validate(value string, _ string, _ bool) (bool, error) {
 	for i, c := range value {
 		// must be letter or digit
 		if !unicode.IsLetter(c) && !unicode.IsDigit(c) {

--- a/internal/rule/pascalcase_test.go
+++ b/internal/rule/pascalcase_test.go
@@ -25,7 +25,7 @@ func TestPascalCase(t *testing.T) {
 
 	i := 0
 	for _, test := range tests {
-		res, err := rule.Validate(test.value, true)
+		res, err := rule.Validate(test.value, "", true)
 
 		if !errors.Is(err, test.err) {
 			t.Errorf("Test %d failed with unmatched error - %e", i, err)

--- a/internal/rule/regex.go
+++ b/internal/rule/regex.go
@@ -71,7 +71,7 @@ func (rule *Regex) GetExclusive() bool {
 }
 
 // Validate checks if full string matches regex
-func (rule *Regex) Validate(value string, fail bool) (bool, error) {
+func (rule *Regex) Validate(value string, path string, _ bool) (bool, error) {
 	match, err := regexp.MatchString("^"+rule.getRegexPattern()+"$", value)
 	return match != rule.negate, err
 }

--- a/internal/rule/regex_test.go
+++ b/internal/rule/regex_test.go
@@ -19,6 +19,8 @@ func TestRegex(t *testing.T) {
 		{params: []string{"[a-z]+"}, value: "123", path: "", expected: false, err: nil},
 		{params: []string{"[a-z\\-]+"}, value: "google-test", path: "", expected: true, err: nil},
 		{params: []string{"[a-z\\-]+"}, value: "google.test", path: "", expected: false, err: nil},
+		{params: []string{"${1}_${0}"}, value: "google_test", path: "google/test", expected: true, err: nil},
+		{params: []string{"${1}_${0}"}, value: "test", path: "google/test", expected: false, err: nil},
 	}
 
 	i := 0

--- a/internal/rule/regex_test.go
+++ b/internal/rule/regex_test.go
@@ -9,15 +9,16 @@ func TestRegex(t *testing.T) {
 	tests := []*struct {
 		params   []string
 		value    string
+		path     string
 		expected bool
 		err      error
 	}{
-		{params: []string{".+"}, value: "regex", expected: true, err: nil},
-		{params: []string{"[0-9]+"}, value: "123", expected: true, err: nil},
-		{params: []string{"![0-9]+"}, value: "123", expected: false, err: nil},
-		{params: []string{"[a-z]+"}, value: "123", expected: false, err: nil},
-		{params: []string{"[a-z\\-]+"}, value: "google-test", expected: true, err: nil},
-		{params: []string{"[a-z\\-]+"}, value: "google.test", expected: false, err: nil},
+		{params: []string{".+"}, value: "regex", path: "", expected: true, err: nil},
+		{params: []string{"[0-9]+"}, value: "123", path: "", expected: true, err: nil},
+		{params: []string{"![0-9]+"}, value: "123", path: "", expected: false, err: nil},
+		{params: []string{"[a-z]+"}, value: "123", path: "", expected: false, err: nil},
+		{params: []string{"[a-z\\-]+"}, value: "google-test", path: "", expected: true, err: nil},
+		{params: []string{"[a-z\\-]+"}, value: "google.test", path: "", expected: false, err: nil},
 	}
 
 	i := 0
@@ -33,7 +34,7 @@ func TestRegex(t *testing.T) {
 		}
 
 		// validate
-		res, err := rule.Validate(test.value, true)
+		res, err := rule.Validate(test.value, test.path, true)
 
 		if err != nil && err != test.err {
 			t.Errorf("Test %d failed with unmatched error - %s", i, err.Error())

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -43,7 +43,8 @@ type Rule interface {
 	// value:
 	//   - file: filename without extension
 	//   - dir: basename
-	Validate(value string, fail bool) (bool, error)
+	// path: full path to file or dir
+	Validate(value string, path string, fail bool) (bool, error)
 	GetErrorMessage() string
 	Copy() Rule
 }

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -43,7 +43,7 @@ type Rule interface {
 	// value:
 	//   - file: filename without extension
 	//   - dir: basename
-	// path: full path to file or dir
+	// path: full dir path - empty on root
 	Validate(value string, path string, fail bool) (bool, error)
 	GetErrorMessage() string
 	Copy() Rule

--- a/internal/rule/screamingsnakecase.go
+++ b/internal/rule/screamingsnakecase.go
@@ -43,7 +43,7 @@ func (rule *ScreamingSnakeCase) GetExclusive() bool {
 
 // Validate checks if string is screaming sneak case
 // false if rune is no uppercase letter, digit or _
-func (rule *ScreamingSnakeCase) Validate(value string, fail bool) (bool, error) {
+func (rule *ScreamingSnakeCase) Validate(value string, _ string, _ bool) (bool, error) {
 	for _, c := range value {
 		if c == 95 || unicode.IsDigit(c) { // 95 => _
 			continue

--- a/internal/rule/screamingsnakecase_test.go
+++ b/internal/rule/screamingsnakecase_test.go
@@ -26,7 +26,7 @@ func TestScreamingSnakeCase(t *testing.T) {
 
 	i := 0
 	for _, test := range tests {
-		res, err := rule.Validate(test.value, true)
+		res, err := rule.Validate(test.value, "", true)
 
 		if !errors.Is(err, test.err) {
 			t.Errorf("Test %d failed with unmatched error - %e", i, err)

--- a/internal/rule/snakecase.go
+++ b/internal/rule/snakecase.go
@@ -43,7 +43,7 @@ func (rule *SnakeCase) GetExclusive() bool {
 
 // Validate checks if string is sneak case
 // false if rune is no lowercase letter, digit or _
-func (rule *SnakeCase) Validate(value string, fail bool) (bool, error) {
+func (rule *SnakeCase) Validate(value string, _ string, _ bool) (bool, error) {
 	for _, c := range value {
 		if c == 95 || unicode.IsDigit(c) { // 95 => _
 			continue

--- a/internal/rule/snakecase_test.go
+++ b/internal/rule/snakecase_test.go
@@ -24,7 +24,7 @@ func TestSnakeCase(t *testing.T) {
 
 	i := 0
 	for _, test := range tests {
-		res, err := rule.Validate(test.value, true)
+		res, err := rule.Validate(test.value, "", true)
 
 		if !errors.Is(err, test.err) {
 			t.Errorf("Test %d failed with unmatched error - %e", i, err)


### PR DESCRIPTION
**supports regex substitutions**

every directory can be referenced by `${i}`
for instance, directory `test/google/linter` will expose 3 variables:

- test: `${2}`
- google: `${1}`
- linter: `${0}`

example:

```yaml
ls: 
    components/**: # e.g.: components/button
        .ts: regex:${0}  # e.g.: components/button/button.ts
        .*.scss: regex:${0} # e.g.: components/button/button.module.scss
        
        tests:
            .test.ts: regex:${1} # e.g.: components/button/tests/button.test.ts
```

**future plans**

- modifiers like `${0:kebab-case}`
- performance optimizations: substitutions can be cached etc

closes #59 