### PR TITLE
refactor: rename receivers for Error struct methods

### DIFF
--- a/internal/rule/error.go
+++ b/internal/rule/error.go
@@ -10,30 +10,30 @@ type Error struct {
 	*sync.RWMutex
 }
 
-func (error *Error) GetPath() string {
-	error.RLock()
-	defer error.RUnlock()
+func (err *Error) GetPath() string {
+	err.RLock()
+	defer err.RUnlock()
 
-	return error.Path
+	return err.Path
 }
 
-func (error *Error) IsDir() bool {
-	error.RLock()
-	defer error.RUnlock()
+func (err *Error) IsDir() bool {
+	err.RLock()
+	defer err.RUnlock()
 
-	return error.Dir
+	return err.Dir
 }
 
-func (error *Error) GetExt() string {
-	error.RLock()
-	defer error.RUnlock()
+func (err *Error) GetExt() string {
+	err.RLock()
+	defer err.RUnlock()
 
-	return error.Ext
+	return err.Ext
 }
 
-func (error *Error) GetRules() []Rule {
-	error.RLock()
-	defer error.RUnlock()
+func (err *Error) GetRules() []Rule {
+	err.RLock()
+	defer err.RUnlock()
 
-	return error.Rules
+	return err.Rules
 }


### PR DESCRIPTION
Because IDEs highlights `error` receiver as the builtin [`error`](https://pkg.go.dev/builtin#error) type
<img width="381" alt="image" src="https://github.com/user-attachments/assets/40f3c0eb-39d7-4575-a7d6-f4a69db950ed" />
