### PR TITLE
fix: ensure compatibility with Windows file paths

### DIFF
--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -142,7 +142,8 @@ func (linter *Linter) validateFile(index config.RuleIndex, path string, validate
 	indexDir, rules := linter.config.GetConfig(index, path)
 
 	var pathDir string
-	if pathDir = filepath.Dir(path); pathDir == "." {
+	pathDir = filepath.ToSlash(filepath.Dir(path)); // compatibility with windows
+	if pathDir == "." {
 		pathDir = ""
 	}
 


### PR DESCRIPTION
Fix for https://github.com/loeffel-io/ls-lint/issues/307:

Issue was that `filepath` functions always return os dependant path separators. Repo  uses:
- `filepath.Base` -> never returns separators ✅ 
- `filepath.Dir` -> potentially returns separators so it is now wrapped with `filepath.ToSlash` 🩹 ✅ 

Bzw, it was lucky that for dir walking `io/fs.WalkDir` was used, which always returns forward slashes. `filepath.WalkDir` would have returned os specific separators as well, leading to the same problem...
