### PR TITLE
fix: skip ignored paths in exists validation

### DIFF
--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -142,7 +142,7 @@ func (linter *Linter) validateFile(index config.RuleIndex, path string, validate
 	indexDir, rules := linter.config.GetConfig(index, path)
 
 	var pathDir string
-	pathDir = filepath.ToSlash(filepath.Dir(path)); // compatibility with windows
+	pathDir = filepath.ToSlash(filepath.Dir(path)) // compatibility with windows
 	if pathDir == "." {
 		pathDir = ""
 	}
@@ -362,6 +362,10 @@ func (linter *Linter) Run(filesystem fs.FS, paths map[string]struct{}, debug boo
 
 	// validate exists
 	for path, pathIndex := range index {
+		if linter.config.ShouldIgnore(ignoreIndex, path) {
+			continue
+		}
+
 		for ext, rules := range pathIndex {
 			if _, ok := pathsIndex[path][ext]; pathsIndex != nil && !ok {
 				continue

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -422,6 +422,60 @@ func TestLinter_Run(t *testing.T) {
 			expectedErrors: []*rule.Error{},
 		},
 		{
+			description: "exists with ignored glob directories",
+			filesystem: fstest.MapFS{
+				"docs":                                           &fstest.MapFile{Mode: fs.ModeDir},
+				"docs/features":                                  &fstest.MapFile{Mode: fs.ModeDir},
+				"docs/features/assets":                           &fstest.MapFile{Mode: fs.ModeDir},
+				"docs/features/feature.yaml":                     &fstest.MapFile{Mode: fs.ModePerm},
+				"docs/features/project_README.md":                &fstest.MapFile{Mode: fs.ModePerm},
+				"docs/features/README.md":                        &fstest.MapFile{Mode: fs.ModePerm},
+				"docs/features/responsibility.yaml":              &fstest.MapFile{Mode: fs.ModePerm},
+				"docs/features/subfeature-1":                     &fstest.MapFile{Mode: fs.ModeDir},
+				"docs/features/subfeature-1/assets":              &fstest.MapFile{Mode: fs.ModeDir},
+				"docs/features/subfeature-1/feature.yaml":        &fstest.MapFile{Mode: fs.ModePerm},
+				"docs/features/subfeature-1/project_README.md":   &fstest.MapFile{Mode: fs.ModePerm},
+				"docs/features/subfeature-1/README.md":           &fstest.MapFile{Mode: fs.ModePerm},
+				"docs/features/subfeature-1/responsibility.yaml": &fstest.MapFile{Mode: fs.ModePerm},
+			},
+			paths: nil,
+			linter: NewLinter(
+				".",
+				config.NewConfig(
+					config.Ls{
+						".dir": "kebab-case",
+						"docs/features/**": config.Ls{
+							".md":   "regex:(README|project_README) | exists:1-2",
+							".yaml": "regex:(feature|responsibility) | exists:2",
+							".*":    "exists:0",
+						},
+					},
+					[]string{
+						"**/assets/**",
+					},
+				),
+				&debug.Statistic{
+					Start:     start,
+					Files:     0,
+					FileSkips: 0,
+					Dirs:      0,
+					DirSkips:  0,
+					RWMutex:   new(sync.RWMutex),
+				},
+				[]*rule.Error{},
+			),
+			expectedErr: nil,
+			expectedStatistic: &debug.Statistic{
+				Start:     start,
+				Files:     8,
+				FileSkips: 0,
+				Dirs:      4,
+				DirSkips:  2,
+				RWMutex:   new(sync.RWMutex),
+			},
+			expectedErrors: []*rule.Error{},
+		},
+		{
 			description: "exists with paths",
 			filesystem: fstest.MapFS{
 				"snake_case.png":                     &fstest.MapFile{Mode: fs.ModePerm},


### PR DESCRIPTION
## Summary
- skip ignored paths during the final `exists` validation pass
- add a regression test matching the ignored `**/assets/**` glob case from #330

## Why
`ignore` was honored while walking the filesystem, but glob-expanded `ls` index entries for ignored directories were still checked later by the `exists` validation pass. Empty ignored directories could therefore report missing `.md` or `.yaml` files even though the directory was skipped.

## Verification
- `go test ./internal/linter -run TestLinter_Run -count=1` failed before the fix with four `exists` errors for ignored asset directories
- `go test ./internal/linter -run TestLinter_Run -count=1`
- `go test ./...`
- `git diff --check`

## AI usage
OpenAI GPT-5 was used to inspect the issue, identify the final `exists` validation path, add the regression test, implement the fix, run verification, and draft this PR description. I reviewed the changed control flow and test fixture before submission.

Fixes #330

