### PR TITLE
feat(config): support extending config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,30 @@ ignore:
   - node_modules
 ```
 
+### Extending configurations
+
+A config can extend one or more other YAML config files:
+
+```yaml
+extends:
+  - node_modules/@enbw/linting/ls-lint/base.yml
+  - ./config/vue.yml
+
+ls:
+  src:
+    .vue: PascalCase
+```
+
+`extends` accepts either one path or an ordered list. Relative paths are
+resolved from the config file that declares them, and absolute paths are also
+supported. Extended configs are loaded first in list order, then the declaring
+config is applied. Like repeated `--config` flags, `ls` uses a shallow
+top-level merge where later values win, while `ignore` entries are combined
+and deduplicated.
+
+Paths inside `node_modules` work when written explicitly. Package-name
+resolution is not supported.
+
 ### Result
 
 <img src="https://i.imgur.com/pxXkYcl.gif" alt="command" width="600">

--- a/cmd/ls_lint/BUILD.bazel
+++ b/cmd/ls_lint/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
         "//internal/flag",
         "//internal/linter",
         "//internal/rule",
-        "@in_yaml_go_yaml_v3//:yaml",
     ],
 )
 

--- a/cmd/ls_lint/main.go
+++ b/cmd/ls_lint/main.go
@@ -5,10 +5,8 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"maps"
 	"os"
 	"runtime"
-	"slices"
 	"strings"
 
 	"github.com/loeffel-io/ls-lint/v2/internal/config"
@@ -16,7 +14,6 @@ import (
 	_flag "github.com/loeffel-io/ls-lint/v2/internal/flag"
 	"github.com/loeffel-io/ls-lint/v2/internal/linter"
 	"github.com/loeffel-io/ls-lint/v2/internal/rule"
-	"go.yaml.in/yaml/v3"
 )
 
 var Version = "dev"
@@ -69,23 +66,9 @@ func main() {
 		}
 	}
 
-	lslintConfig := config.NewConfig(make(config.Ls), make([]string, 0))
-	for _, c := range flagConfig {
-		tmpLslintConfig := config.NewConfig(nil, nil)
-		var tmpConfigBytes []byte
-
-		if tmpConfigBytes, err = os.ReadFile(c); err != nil {
-			log.Fatal(err)
-		}
-
-		if err = yaml.Unmarshal(tmpConfigBytes, tmpLslintConfig); err != nil {
-			log.Fatal(err)
-		}
-
-		maps.Copy(lslintConfig.GetLs(), tmpLslintConfig.GetLs())
-		lslintConfig.Ignore = append(lslintConfig.Ignore, tmpLslintConfig.GetIgnore()...)
-		slices.Sort(lslintConfig.Ignore)
-		lslintConfig.Ignore = slices.Compact(lslintConfig.Ignore)
+	lslintConfig, err := config.Load([]string(flagConfig))
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	lslintLinter := linter.NewLinter(

--- a/internal/config/BUILD.bazel
+++ b/internal/config/BUILD.bazel
@@ -2,15 +2,24 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "config",
-    srcs = ["config.go"],
+    srcs = [
+        "config.go",
+        "loader.go",
+    ],
     importpath = "github.com/loeffel-io/ls-lint/v2/internal/config",
     visibility = ["//:__subpackages__"],
-    deps = ["//internal/rule"],
+    deps = [
+        "//internal/rule",
+        "@in_yaml_go_yaml_v3//:yaml",
+    ],
 )
 
 go_test(
     name = "config_test",
-    srcs = ["config_test.go"],
+    srcs = [
+        "config_test.go",
+        "loader_test.go",
+    ],
     embed = [":config"],
     deps = ["//internal/rule"],
 )

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -1,0 +1,133 @@
+package config
+
+import (
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"go.yaml.in/yaml/v3"
+)
+
+type configFile struct {
+	Extends extendsList `yaml:"extends"`
+	Ls      Ls          `yaml:"ls"`
+	Ignore  []string    `yaml:"ignore"`
+}
+
+type extendsList []string
+
+func (list *extendsList) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.ScalarNode:
+		if value.Tag != "!!str" || strings.TrimSpace(value.Value) == "" {
+			return fmt.Errorf("extends must be a non-empty string or list of non-empty strings")
+		}
+
+		*list = extendsList{value.Value}
+		return nil
+	case yaml.SequenceNode:
+		paths := make(extendsList, 0, len(value.Content))
+		for _, item := range value.Content {
+			if item.Kind != yaml.ScalarNode || item.Tag != "!!str" || strings.TrimSpace(item.Value) == "" {
+				return fmt.Errorf("extends must be a non-empty string or list of non-empty strings")
+			}
+
+			paths = append(paths, item.Value)
+		}
+
+		*list = paths
+		return nil
+	default:
+		return fmt.Errorf("extends must be a non-empty string or list of non-empty strings")
+	}
+}
+
+type loader struct {
+	active map[string]int
+	stack  []string
+}
+
+// Load reads and merges config files in order. Each config may extend other
+// config files, which are merged before the config that declares them.
+func Load(paths []string) (*Config, error) {
+	result := NewConfig(make(Ls), make([]string, 0))
+	configLoader := loader{
+		active: make(map[string]int),
+		stack:  make([]string, 0),
+	}
+
+	for _, path := range paths {
+		loaded, err := configLoader.load(path)
+		if err != nil {
+			return nil, err
+		}
+
+		merge(result, loaded)
+	}
+
+	slices.Sort(result.Ignore)
+	result.Ignore = slices.Compact(result.Ignore)
+
+	return result, nil
+}
+
+func (configLoader *loader) load(path string) (*Config, error) {
+	absolutePath, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return nil, fmt.Errorf("resolve config %q: %w", path, err)
+	}
+
+	identity := absolutePath
+	if evaluatedPath, evaluateErr := filepath.EvalSymlinks(absolutePath); evaluateErr == nil {
+		identity = evaluatedPath
+	}
+
+	if index, ok := configLoader.active[identity]; ok {
+		chain := append(slices.Clone(configLoader.stack[index:]), absolutePath)
+		return nil, fmt.Errorf("config extends cycle: %s", strings.Join(chain, " -> "))
+	}
+
+	configLoader.active[identity] = len(configLoader.stack)
+	configLoader.stack = append(configLoader.stack, absolutePath)
+	defer func() {
+		delete(configLoader.active, identity)
+		configLoader.stack = configLoader.stack[:len(configLoader.stack)-1]
+	}()
+
+	configBytes, err := os.ReadFile(absolutePath)
+	if err != nil {
+		return nil, fmt.Errorf("read config %q: %w", absolutePath, err)
+	}
+
+	var parsed configFile
+	if err = yaml.Unmarshal(configBytes, &parsed); err != nil {
+		return nil, fmt.Errorf("parse config %q: %w", absolutePath, err)
+	}
+
+	result := NewConfig(make(Ls), make([]string, 0))
+	for _, extendedPath := range parsed.Extends {
+		resolvedPath := extendedPath
+		if !filepath.IsAbs(resolvedPath) {
+			resolvedPath = filepath.Join(filepath.Dir(absolutePath), resolvedPath)
+		}
+
+		extendedConfig, loadErr := configLoader.load(resolvedPath)
+		if loadErr != nil {
+			return nil, fmt.Errorf("config %q extends %q: %w", absolutePath, extendedPath, loadErr)
+		}
+
+		merge(result, extendedConfig)
+	}
+
+	merge(result, NewConfig(parsed.Ls, parsed.Ignore))
+
+	return result, nil
+}
+
+func merge(target *Config, source *Config) {
+	maps.Copy(target.Ls, source.Ls)
+	target.Ignore = append(target.Ignore, source.Ignore...)
+}

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -1,0 +1,278 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestLoadExtendsAndMerge(t *testing.T) {
+	root := t.TempDir()
+	writeConfig(t, root, "node_modules/team/base.yml", `
+ls:
+  src:
+    .js: camelcase
+    .ts: camelcase
+  shared:
+    .ts: camelcase
+ignore:
+  - node_modules
+  - generated
+`)
+	writeConfig(t, root, "config/vue.yml", `
+extends: ../node_modules/team/base.yml
+ls:
+  src:
+    .vue: PascalCase
+ignore:
+  - dist
+`)
+	writeConfig(t, root, "config/react.yml", `
+ls:
+  react:
+    .tsx: PascalCase
+ignore:
+  - dist
+`)
+	rootConfig := writeConfig(t, root, ".ls-lint.yml", `
+extends:
+  - config/vue.yml
+  - config/react.yml
+ls:
+  shared:
+    .ts: PascalCase
+ignore:
+  - coverage
+`)
+
+	loaded, err := Load([]string{rootConfig})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedLs := Ls{
+		"src": Ls{
+			".vue": "PascalCase",
+		},
+		"shared": Ls{
+			".ts": "PascalCase",
+		},
+		"react": Ls{
+			".tsx": "PascalCase",
+		},
+	}
+	if !reflect.DeepEqual(loaded.Ls, expectedLs) {
+		t.Errorf("unexpected ls config:\nexpected: %#v\nactual:   %#v", expectedLs, loaded.Ls)
+	}
+
+	expectedIgnore := []string{"coverage", "dist", "generated", "node_modules"}
+	if !reflect.DeepEqual(loaded.Ignore, expectedIgnore) {
+		t.Errorf("unexpected ignore config: expected %v, actual %v", expectedIgnore, loaded.Ignore)
+	}
+}
+
+func TestLoadAbsolutePathAndExtendsOnlyConfig(t *testing.T) {
+	root := t.TempDir()
+	base := writeConfig(t, root, "shared/base.yml", `
+ls:
+  packages:
+    .js: kebab-case
+`)
+	rootConfig := writeConfig(t, root, ".ls-lint.yml", fmt.Sprintf("extends: '%s'\n", strings.ReplaceAll(base, "'", "''")))
+
+	loaded, err := Load([]string{rootConfig})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := loaded.Ls["packages"]; !ok {
+		t.Errorf("expected absolute extended config to be loaded: %#v", loaded.Ls)
+	}
+}
+
+func TestLoadRepeatedRootsPreservesOrder(t *testing.T) {
+	root := t.TempDir()
+	base := writeConfig(t, root, "base.yml", `
+ls:
+  src:
+    .js: camelcase
+  base:
+    .md: kebab-case
+ignore:
+  - generated
+`)
+	local := writeConfig(t, root, "local.yml", `
+ls:
+  src:
+    .ts: PascalCase
+ignore:
+  - generated
+  - coverage
+`)
+
+	loaded, err := Load([]string{base, local})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedLs := Ls{
+		"src": Ls{
+			".ts": "PascalCase",
+		},
+		"base": Ls{
+			".md": "kebab-case",
+		},
+	}
+	if !reflect.DeepEqual(loaded.Ls, expectedLs) {
+		t.Errorf("unexpected ls config:\nexpected: %#v\nactual:   %#v", expectedLs, loaded.Ls)
+	}
+
+	expectedIgnore := []string{"coverage", "generated"}
+	if !reflect.DeepEqual(loaded.Ignore, expectedIgnore) {
+		t.Errorf("unexpected ignore config: expected %v, actual %v", expectedIgnore, loaded.Ignore)
+	}
+}
+
+func TestLoadDiamondReappliesSharedConfig(t *testing.T) {
+	root := t.TempDir()
+	writeConfig(t, root, "shared.yml", `
+ls:
+  shared:
+    .js: camelcase
+`)
+	writeConfig(t, root, "left.yml", `
+extends: shared.yml
+ls:
+  shared:
+    .js: PascalCase
+  left:
+    .js: camelcase
+`)
+	writeConfig(t, root, "right.yml", `
+extends: shared.yml
+ls:
+  right:
+    .js: camelcase
+`)
+	rootConfig := writeConfig(t, root, "root.yml", `
+extends:
+  - left.yml
+  - right.yml
+`)
+
+	loaded, err := Load([]string{rootConfig})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedShared := Ls{".js": "camelcase"}
+	if !reflect.DeepEqual(loaded.Ls["shared"], expectedShared) {
+		t.Errorf("expected right branch to reapply shared config, got %#v", loaded.Ls["shared"])
+	}
+}
+
+func TestLoadErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		files       map[string]string
+		root        string
+		expectedErr []string
+	}{
+		{
+			name: "invalid scalar",
+			files: map[string]string{
+				"root.yml": "extends: 42\n",
+			},
+			root:        "root.yml",
+			expectedErr: []string{"parse config", "extends must be"},
+		},
+		{
+			name: "invalid list item",
+			files: map[string]string{
+				"root.yml": "extends:\n  - base.yml\n  - 42\n",
+			},
+			root:        "root.yml",
+			expectedErr: []string{"parse config", "extends must be"},
+		},
+		{
+			name: "empty path",
+			files: map[string]string{
+				"root.yml": "extends: '  '\n",
+			},
+			root:        "root.yml",
+			expectedErr: []string{"parse config", "non-empty"},
+		},
+		{
+			name: "missing child",
+			files: map[string]string{
+				"root.yml": "extends: missing.yml\n",
+			},
+			root:        "root.yml",
+			expectedErr: []string{`extends "missing.yml"`, "read config"},
+		},
+		{
+			name: "malformed child",
+			files: map[string]string{
+				"root.yml": "extends: bad.yml\n",
+				"bad.yml":  "ls: [\n",
+			},
+			root:        "root.yml",
+			expectedErr: []string{`extends "bad.yml"`, "parse config"},
+		},
+		{
+			name: "self cycle",
+			files: map[string]string{
+				"root.yml": "extends: root.yml\n",
+			},
+			root:        "root.yml",
+			expectedErr: []string{"config extends cycle", "root.yml"},
+		},
+		{
+			name: "indirect cycle",
+			files: map[string]string{
+				"a.yml": "extends: b.yml\n",
+				"b.yml": "extends: a.yml\n",
+			},
+			root:        "a.yml",
+			expectedErr: []string{"config extends cycle", "a.yml", "b.yml"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			for path, content := range test.files {
+				writeConfig(t, root, path, content)
+			}
+
+			_, err := Load([]string{filepath.Join(root, test.root)})
+			if err == nil {
+				t.Fatal("expected load error")
+			}
+
+			for _, expected := range test.expectedErr {
+				if !strings.Contains(err.Error(), expected) {
+					t.Errorf("expected error to contain %q, got %q", expected, err)
+				}
+			}
+		})
+	}
+}
+
+func writeConfig(t *testing.T, root string, path string, content string) string {
+	t.Helper()
+
+	absolutePath := filepath.Join(root, filepath.FromSlash(path))
+	if err := os.MkdirAll(filepath.Dir(absolutePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(absolutePath, []byte(strings.TrimSpace(content)+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	return absolutePath
+}


### PR DESCRIPTION
## Summary

- Add recursive YAML config composition using `extends`.
- Preserve shallow `ls` merging and combined `ignore` behavior.
- Support relative, absolute, and explicit `node_modules` paths.
- Add cycle detection, contextual errors, tests, and documentation.

Fixes #363

## Testing

- [x] `go test ./...`
- [x] `bazel test //...`
- [x] `bazel build //...`
- [x] `bazel run //:gazelle_fix_diff`
- [x] Repeated-config versus composed-config CLI smoke test
- [x] Changed Go files checked with `gofumpt`

The repository format wrapper itself cannot run from this checkout because its generated shell script does not quote the workspace path, which contains spaces. The changed Go files pass a direct `gofumpt` check.

## Risks

- `extends` becomes a new public YAML key.
- Merging intentionally remains shallow for compatibility.
- Bare npm package resolution is outside this change.

## AI assistance

OpenAI Codex assisted with research, implementation, tests, documentation, and PR drafting. I reviewed and understand the PR.
